### PR TITLE
Refactor Paradox COMBUS reader to polling mode for ESP32/ESP8266 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Paradox-ESPHome
 
-Connect Paradox COMBUS (green-yellow wires which connect alarm system to the keypad) alarm interface to Home Assistant using esp8266 device and ESPHome library.
+Connect Paradox COMBUS (green-yellow wires which connect alarm system to the keypad) alarm interface to Home Assistant using ESP8266/ESP32 device and ESPHome library.
 
 Currently the implementation is read-only, it shows motion, window/door, smoke sensor and alarm state status in Home Assistant (with a slight delay).
 
@@ -12,7 +12,7 @@ Because Combus operates at ~12v, we need to step down voltage to levels suitable
 
 Wiring example:
 
-      Alarm Aux(+) --- Voltage regulator (5v for Wemos, NodeMCU, 3.3V for generic esp8266) --- VIN pin on esp8266
+      Alarm Aux(+) --- Voltage regulator (5v for Wemos, NodeMCU, 3.3V for generic ESP8266/ESP32) --- VIN pin on esp8266
 
       Alarm Aux(-) --- esp8266 Ground
 
@@ -27,6 +27,8 @@ Wiring example:
 ## Native ESPHome component usage
 
 This repository now includes a native ESPHome **external component** (`components/paradox_combus`) that exposes:
+
+- ESP8266/ESP32-compatible COMBUS reader implemented as a native polling loop (no timer/interrupt dependency)
 
 - `paradox_combus:` hub configuration
 - `binary_sensor` platform `paradox_combus` with per-zone sensors

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -6,7 +6,6 @@ namespace esphome {
 namespace paradox_combus {
 
 static const char *const TAG = "paradox_combus";
-ParadoxCombusComponent *ParadoxCombusComponent::instance_ = nullptr;
 
 void ParadoxCombusComponent::register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor) {
   if (zone < 1 || zone > 32) {
@@ -16,37 +15,32 @@ void ParadoxCombusComponent::register_zone_sensor(uint8_t zone, binary_sensor::B
   this->zone_sensors_[zone - 1] = sensor;
 }
 
-void IRAM_ATTR ParadoxCombusComponent::interrupt_clock_falling_() {
-  if (instance_ == nullptr) {
+void ParadoxCombusComponent::capture_combus_bits_() {
+  if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
     return;
   }
 
-  instance_->last_clk_signal_ = micros();
-  instance_->clk_pin_triggered_ = true;
-  timer1_write(750);
-}
+  const unsigned long now = micros();
+  const bool clk_state = this->clk_pin_->digital_read();
 
-void IRAM_ATTR ParadoxCombusComponent::read_data_pin_() {
-  if (instance_ == nullptr || instance_->dta_pin_ == nullptr) {
+  if (this->last_clk_state_ && !clk_state) {
+    this->last_clk_signal_ = now;
+    this->pending_sample_at_ = now + 150;
+    this->sample_pending_ = true;
+  }
+  this->last_clk_state_ = clk_state;
+
+  if (!this->sample_pending_ || static_cast<long>(now - this->pending_sample_at_) < 0) {
     return;
   }
 
-  if (!instance_->clk_pin_triggered_) {
-    return;
-  }
+  this->sample_pending_ = false;
 
-  while (micros() - instance_->last_clk_signal_ < 150) {
-  }
+  this->bus_message_.push_back(this->dta_pin_->digital_read() ? '0' : '1');
 
-  if (!instance_->dta_pin_->digital_read())
-    instance_->bus_message_ += "1";
-  else
-    instance_->bus_message_ += "0";
-
-  instance_->clk_pin_triggered_ = false;
-
-  if (instance_->bus_message_.length() > 200) {
-    instance_->bus_message_ = "";
+  if (this->bus_message_.length() > 200) {
+    this->bus_message_.clear();
+    ESP_LOGW(TAG, "Dropped COMBUS frame buffer due to overflow");
     return;
   }
 }
@@ -60,27 +54,22 @@ void ParadoxCombusComponent::connect_combus_() {
   this->clk_pin_->pin_mode(gpio::FLAG_INPUT);
   this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
 
-  attachInterrupt(this->clk_pin_->get_pin(), &ParadoxCombusComponent::interrupt_clock_falling_, FALLING);
-  timer1_attachInterrupt(&ParadoxCombusComponent::read_data_pin_);
-  timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
+  this->last_clk_state_ = this->clk_pin_->digital_read();
+  this->sample_pending_ = false;
+  this->last_clk_signal_ = micros();
+  this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
-  ESP_LOGI(TAG, "COMBUS initialized");
+  ESP_LOGI(TAG, "COMBUS initialized in polling mode");
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {
-  timer1_disable();
-  timer1_detachInterrupt();
-
-  if (this->clk_pin_ != nullptr) {
-    detachInterrupt(this->clk_pin_->get_pin());
-  }
-
+  this->sample_pending_ = false;
+  this->bus_message_.clear();
   this->combus_connection_status_ = false;
 }
 
 void ParadoxCombusComponent::setup() {
-  instance_ = this;
   this->connect_combus_();
 }
 
@@ -109,17 +98,24 @@ void ParadoxCombusComponent::loop() {
     return;
   }
 
+  this->capture_combus_bits_();
+
   if (!this->check_clock_idle_() || this->bus_message_.length() < 2) {
     return;
   }
 
-  String message = this->bus_message_;
-  this->bus_message_ = "";
+  String message = this->bus_message_.c_str();
+  this->bus_message_.clear();
 
   this->decode_message_(message);
 }
 
 void ParadoxCombusComponent::process_zone_status_(String &msg) {
+  if (msg.length() < 17 + (32 * 2)) {
+    ESP_LOGW(TAG, "Zone frame too short: %u bits", msg.length());
+    return;
+  }
+
   for (int i = 0; i < 32; i++) {
     bool open = msg[17 + (i * 2)] == '1';
     this->publish_zone_state_(i + 1, open);
@@ -127,6 +123,11 @@ void ParadoxCombusComponent::process_zone_status_(String &msg) {
 }
 
 void ParadoxCombusComponent::process_alarm_status_(String &msg) {
+  if (msg.length() <= ((8 * 7) + 1)) {
+    ESP_LOGW(TAG, "Alarm frame too short: %u bits", msg.length());
+    return;
+  }
+
   if (msg[((8 * 7) + 1)] == '0') {
     if (msg[((8 * 2) + 5)] == '1') {
       this->publish_alarm_state_(STATUS_STAY);
@@ -149,6 +150,10 @@ void ParadoxCombusComponent::process_alarm_status_(String &msg) {
 }
 
 void ParadoxCombusComponent::decode_message_(String &msg) {
+  if (msg.length() < 8) {
+    return;
+  }
+
   int cmd = get_int_from_string_(msg.substring(0, 8));
 
   if (cmd == 0xD0 || cmd == 0xD1) {
@@ -193,6 +198,9 @@ uint8_t ParadoxCombusComponent::crc8_(uint8_t *addr, uint8_t len) {
 
 uint8_t ParadoxCombusComponent::check_crc_(String &st) {
   int bytes = (st.length()) / 8;
+  if (bytes < 2) {
+    return false;
+  }
   uint8_t calc_crc_byte;
 
   uint8_t *binary_str = str_to_bin_array_(st);

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -6,6 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 
 #include <array>
+#include <string>
 
 namespace esphome {
 namespace paradox_combus {
@@ -41,9 +42,7 @@ class ParadoxCombusComponent : public Component {
 
   void publish_alarm_state_(const std::string &value);
   void publish_zone_state_(uint8_t zone, bool open);
-
-  static void IRAM_ATTR interrupt_clock_falling_();
-  static void IRAM_ATTR read_data_pin_();
+  void capture_combus_bits_();
 
   InternalGPIOPin *clk_pin_{nullptr};
   InternalGPIOPin *dta_pin_{nullptr};
@@ -51,9 +50,11 @@ class ParadoxCombusComponent : public Component {
   std::array<binary_sensor::BinarySensor *, 32> zone_sensors_{};
   text_sensor::TextSensor *alarm_status_sensor_{nullptr};
 
-  String bus_message_;
-  volatile unsigned long last_clk_signal_{0};
-  volatile bool clk_pin_triggered_{false};
+  std::string bus_message_;
+  bool last_clk_state_{true};
+  bool sample_pending_{false};
+  unsigned long pending_sample_at_{0};
+  unsigned long last_clk_signal_{0};
   bool combus_connection_status_{false};
 
   const std::string STATUS_UNAVAILABLE = "unavailable";
@@ -61,8 +62,6 @@ class ParadoxCombusComponent : public Component {
   const std::string STATUS_SLEEP = "armed_night";
   const std::string STATUS_STAY = "armed_home";
   const std::string STATUS_OFF = "disarmed";
-
-  static ParadoxCombusComponent *instance_;
 };
 
 }  // namespace paradox_combus


### PR DESCRIPTION
### Motivation
- The interrupt/timer-based COMBUS sampling was unreliable on ESP32 hardware, so the reader was refactored to a polling/edge-capture model inspired by the M5Stack approach to reliably grab clock/data samples. 
- The change also broadens support to ESP8266 and ESP32 by avoiding fragile timer/ISR plumbing.

### Description
- Replaced ISR/timer capture path with a new `capture_combus_bits_()` polling edge-detection method that detects falling clock edges, schedules a delayed data sample, and appends bits into a `std::string` frame buffer. 
- Removed singleton/ISR-only state and introduced explicit polling state fields (`last_clk_state_`, `sample_pending_`, `pending_sample_at_`) and switched frame buffer type from `String` to `std::string` for safer management. 
- Updated `connect_combus_()`/`disconnect_combus_()` to initialize and reset polling state instead of attaching/detaching interrupts and timers, and changed logging to indicate polling mode. 
- Added defensive frame-length checks in `process_zone_status_()`, `process_alarm_status_()`, `decode_message_()`, and CRC preconditions to prevent out-of-bounds parsing of malformed frames. 
- Documentation updated in `README.md` to call out ESP8266/ESP32 compatibility and the new native polling-mode COMBUS reader.

### Testing
- Ran `python -m compileall components/paradox_combus` and the Python component files compiled successfully. 
- No further automated runtime tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1aeef664832f97a54adc66be1e79)