### PR TITLE
Add experimental Paradox COMBUS write path with alarm_control_panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Connect Paradox COMBUS (green-yellow wires which connect alarm system to the keypad) alarm interface to Home Assistant using ESP8266/ESP32 device and ESPHome library.
 
-Currently the implementation is read-only, it shows motion, window/door, smoke sensor and alarm state status in Home Assistant (with a slight delay).
+The implementation can read COMBUS zone/alarm status and now includes an **experimental** COMBUS writer that can be mapped to Home Assistant alarm actions via `alarm_control_panel` (arming/disarming sequences still depend on panel model/programming).
 
 ## Example in Home Assistant
 ![Image of HASS example](https://github.com/Margriko/Paradox-ESPHome/blob/master/images/hass-example.png)
@@ -33,6 +33,7 @@ This repository now includes a native ESPHome **external component** (`component
 - `paradox_combus:` hub configuration
 - `binary_sensor` platform `paradox_combus` with per-zone sensors
 - `text_sensor` platform `paradox_combus` for alarm status
+- `alarm_control_panel` platform `paradox_combus` for arm/disarm commands (experimental write support)
 
 That means there is no need for `custom_component` + `template` sensor callback wiring.
 
@@ -61,6 +62,19 @@ text_sensor:
     paradox_combus_id: combus
     type: alarm_status
     name: "Alarm Status"
+```
+
+Alarm control panel YAML (experimental write path):
+
+```yaml
+alarm_control_panel:
+  - platform: paradox_combus
+    paradox_combus_id: combus
+    name: "Alarm"
+    disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    arm_home_sequence: [0x53]
+    arm_away_sequence: [0x41]
+    arm_night_sequence: [0x4E]
 ```
 
 For a full multi-zone example, see `alarm.yaml`.

--- a/alarm.yaml
+++ b/alarm.yaml
@@ -89,3 +89,14 @@ text_sensor:
     type: alarm_status
     name: "Alarm Status"
     icon: "mdi:shield"
+
+
+alarm_control_panel:
+  - platform: paradox_combus
+    paradox_combus_id: combus
+    name: "Alarm"
+    # IMPORTANT: these are example bytes and will likely need adjustment for your panel/code.
+    disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    arm_home_sequence: [0x53]
+    arm_away_sequence: [0x41]
+    arm_night_sequence: [0x4E]

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -4,10 +4,11 @@ from esphome import pins
 from esphome.const import CONF_ID
 
 CODEOWNERS = ["@Margriko"]
-AUTO_LOAD = ["binary_sensor", "text_sensor"]
+AUTO_LOAD = ["alarm_control_panel", "binary_sensor", "text_sensor"]
 
 paradox_combus_ns = cg.esphome_ns.namespace("paradox_combus")
 ParadoxCombusComponent = paradox_combus_ns.class_("ParadoxCombusComponent", cg.Component)
+ParadoxAlarmControlPanel = paradox_combus_ns.class_("ParadoxAlarmControlPanel")
 
 CONF_CLK_PIN = "clk_pin"
 CONF_DTA_PIN = "dta_pin"

--- a/components/paradox_combus/alarm_control_panel.py
+++ b/components/paradox_combus/alarm_control_panel.py
@@ -1,0 +1,63 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import alarm_control_panel
+from esphome.const import CONF_ID
+
+from . import ParadoxAlarmControlPanel, ParadoxCombusComponent
+
+DEPENDENCIES = ["paradox_combus"]
+
+CONF_PARADOX_COMBUS_ID = "paradox_combus_id"
+CONF_DISARM_SEQUENCE = "disarm_sequence"
+CONF_ARM_HOME_SEQUENCE = "arm_home_sequence"
+CONF_ARM_AWAY_SEQUENCE = "arm_away_sequence"
+CONF_ARM_NIGHT_SEQUENCE = "arm_night_sequence"
+
+
+def _validate_non_empty(config):
+    if not any(
+        config.get(key)
+        for key in (
+            CONF_DISARM_SEQUENCE,
+            CONF_ARM_HOME_SEQUENCE,
+            CONF_ARM_AWAY_SEQUENCE,
+            CONF_ARM_NIGHT_SEQUENCE,
+        )
+    ):
+        raise cv.Invalid(
+            "At least one write sequence must be configured (disarm_sequence/arm_home_sequence/"
+            "arm_away_sequence/arm_night_sequence)"
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    alarm_control_panel.alarm_control_panel_schema(ParadoxAlarmControlPanel).extend(
+        {
+            cv.GenerateID(CONF_PARADOX_COMBUS_ID): cv.use_id(ParadoxCombusComponent),
+            cv.Optional(CONF_DISARM_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
+            cv.Optional(CONF_ARM_HOME_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
+            cv.Optional(CONF_ARM_AWAY_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
+            cv.Optional(CONF_ARM_NIGHT_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
+        }
+    ),
+    _validate_non_empty,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await alarm_control_panel.register_alarm_control_panel(var, config)
+
+    hub = await cg.get_variable(config[CONF_PARADOX_COMBUS_ID])
+    cg.add(var.set_parent(hub))
+    cg.add(hub.set_alarm_control_panel(var))
+
+    if CONF_DISARM_SEQUENCE in config:
+        cg.add(hub.set_disarm_sequence(config[CONF_DISARM_SEQUENCE]))
+    if CONF_ARM_HOME_SEQUENCE in config:
+        cg.add(hub.set_arm_home_sequence(config[CONF_ARM_HOME_SEQUENCE]))
+    if CONF_ARM_AWAY_SEQUENCE in config:
+        cg.add(hub.set_arm_away_sequence(config[CONF_ARM_AWAY_SEQUENCE]))
+    if CONF_ARM_NIGHT_SEQUENCE in config:
+        cg.add(hub.set_arm_night_sequence(config[CONF_ARM_NIGHT_SEQUENCE]))

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -7,6 +7,30 @@ namespace paradox_combus {
 
 static const char *const TAG = "paradox_combus";
 
+void ParadoxAlarmControlPanel::control(const alarm_control_panel::AlarmControlPanelCall &call) {
+  if (this->parent_ == nullptr || !call.get_state().has_value()) {
+    return;
+  }
+
+  switch (*call.get_state()) {
+    case alarm_control_panel::ACP_STATE_DISARMED:
+      this->parent_->request_disarm();
+      break;
+    case alarm_control_panel::ACP_STATE_ARMED_HOME:
+      this->parent_->request_arm_home();
+      break;
+    case alarm_control_panel::ACP_STATE_ARMED_AWAY:
+      this->parent_->request_arm_away();
+      break;
+    case alarm_control_panel::ACP_STATE_ARMED_NIGHT:
+      this->parent_->request_arm_night();
+      break;
+    default:
+      ESP_LOGW(TAG, "Requested alarm state is not currently mapped to COMBUS write sequence");
+      break;
+  }
+}
+
 void ParadoxCombusComponent::register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor) {
   if (zone < 1 || zone > 32) {
     ESP_LOGW(TAG, "Ignoring zone %u (valid range is 1..32)", zone);
@@ -45,6 +69,60 @@ void ParadoxCombusComponent::capture_combus_bits_() {
   }
 }
 
+void ParadoxCombusComponent::queue_write_sequence_(const std::vector<uint8_t> &sequence) {
+  if (sequence.empty()) {
+    ESP_LOGW(TAG, "Cannot queue empty COMBUS write sequence");
+    return;
+  }
+
+  for (uint8_t value : sequence) {
+    for (uint8_t bit = 0; bit < 8; bit++) {
+      this->tx_bits_.push_back((value >> bit) & 0x01);
+    }
+  }
+
+  ESP_LOGD(TAG, "Queued COMBUS write sequence (%u bytes, %u bits pending)", static_cast<unsigned>(sequence.size()),
+           static_cast<unsigned>(this->tx_bits_.size()));
+}
+
+void ParadoxCombusComponent::request_disarm() { this->queue_write_sequence_(this->disarm_sequence_); }
+
+void ParadoxCombusComponent::request_arm_home() { this->queue_write_sequence_(this->arm_home_sequence_); }
+
+void ParadoxCombusComponent::request_arm_away() { this->queue_write_sequence_(this->arm_away_sequence_); }
+
+void ParadoxCombusComponent::request_arm_night() { this->queue_write_sequence_(this->arm_night_sequence_); }
+
+void ParadoxCombusComponent::process_pending_bus_writes_() {
+  if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
+    return;
+  }
+
+  if (this->tx_bits_.empty()) {
+    if (this->tx_drive_low_) {
+      this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+      this->tx_drive_low_ = false;
+    }
+    return;
+  }
+
+  const bool clk_state = this->clk_pin_->digital_read();
+  if (this->last_clk_state_ && !clk_state) {
+    const bool write_bit = this->tx_bits_.front();
+    this->tx_bits_.pop_front();
+
+    // COMBUS uses open collector signalling: logical '1' is driven low, logical '0' is release.
+    if (write_bit) {
+      this->dta_pin_->pin_mode(gpio::FLAG_OUTPUT);
+      this->dta_pin_->digital_write(false);
+      this->tx_drive_low_ = true;
+    } else {
+      this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+      this->tx_drive_low_ = false;
+    }
+  }
+}
+
 void ParadoxCombusComponent::connect_combus_() {
   if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
     ESP_LOGE(TAG, "clk_pin and dta_pin are required");
@@ -65,17 +143,24 @@ void ParadoxCombusComponent::connect_combus_() {
 
 void ParadoxCombusComponent::disconnect_combus_() {
   this->sample_pending_ = false;
+  this->tx_bits_.clear();
+  this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+  this->tx_drive_low_ = false;
   this->bus_message_.clear();
   this->combus_connection_status_ = false;
 }
 
-void ParadoxCombusComponent::setup() {
-  this->connect_combus_();
-}
+void ParadoxCombusComponent::setup() { this->connect_combus_(); }
 
 void ParadoxCombusComponent::publish_alarm_state_(const std::string &value) {
   if (this->alarm_status_sensor_ != nullptr) {
     this->alarm_status_sensor_->publish_state(value);
+  }
+}
+
+void ParadoxCombusComponent::publish_alarm_control_panel_state_(alarm_control_panel::AlarmControlPanelState state) {
+  if (this->alarm_control_panel_ != nullptr) {
+    this->alarm_control_panel_->publish_state(state);
   }
 }
 
@@ -92,6 +177,7 @@ void ParadoxCombusComponent::publish_zone_state_(uint8_t zone, bool open) {
 void ParadoxCombusComponent::loop() {
   if (!this->get_combus_connection_status_()) {
     this->publish_alarm_state_(STATUS_UNAVAILABLE);
+    this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_DISARMED);
     for (int i = 0; i < 32; i++) {
       this->publish_zone_state_(i + 1, false);
     }
@@ -99,6 +185,7 @@ void ParadoxCombusComponent::loop() {
   }
 
   this->capture_combus_bits_();
+  this->process_pending_bus_writes_();
 
   if (!this->check_clock_idle_() || this->bus_message_.length() < 2) {
     return;
@@ -131,21 +218,27 @@ void ParadoxCombusComponent::process_alarm_status_(String &msg) {
   if (msg[((8 * 7) + 1)] == '0') {
     if (msg[((8 * 2) + 5)] == '1') {
       this->publish_alarm_state_(STATUS_STAY);
+      this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_ARMED_HOME);
     }
     if (msg[((8 * 6) + 5)] == '1') {
       this->publish_alarm_state_(STATUS_SLEEP);
+      this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_ARMED_NIGHT);
     }
     if (msg[((8 * 2) + 1)] == '1') {
       if (msg[((8 * 2) + 0)] == '1') {
         this->publish_alarm_state_("exit");
+        this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_ARMING);
       } else if (msg[((8 * 2) + 0)] == '0') {
         this->publish_alarm_state_("fullalarm");
+        this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_TRIGGERED);
       } else {
         this->publish_alarm_state_(STATUS_ARM);
+        this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_ARMED_AWAY);
       }
     }
   } else {
     this->publish_alarm_state_(STATUS_OFF);
+    this->publish_alarm_control_panel_state_(alarm_control_panel::ACP_STATE_DISARMED);
   }
 }
 

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -2,15 +2,29 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/components/alarm_control_panel/alarm_control_panel.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 #include <array>
+#include <cstdint>
+#include <deque>
 #include <string>
+#include <vector>
 
 namespace esphome {
 namespace paradox_combus {
 
+class ParadoxCombusComponent;
+
+class ParadoxAlarmControlPanel : public alarm_control_panel::AlarmControlPanel {
+ public:
+  void set_parent(ParadoxCombusComponent *parent) { this->parent_ = parent; }
+
+ protected:
+  void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
+  ParadoxCombusComponent *parent_{nullptr};
+};
 
 class ParadoxZoneBinarySensor : public binary_sensor::BinarySensor {};
 
@@ -21,6 +35,17 @@ class ParadoxCombusComponent : public Component {
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_status_sensor(text_sensor::TextSensor *sensor) { this->alarm_status_sensor_ = sensor; }
+  void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
+
+  void set_disarm_sequence(const std::vector<uint8_t> &sequence) { this->disarm_sequence_ = sequence; }
+  void set_arm_home_sequence(const std::vector<uint8_t> &sequence) { this->arm_home_sequence_ = sequence; }
+  void set_arm_away_sequence(const std::vector<uint8_t> &sequence) { this->arm_away_sequence_ = sequence; }
+  void set_arm_night_sequence(const std::vector<uint8_t> &sequence) { this->arm_night_sequence_ = sequence; }
+
+  void request_disarm();
+  void request_arm_home();
+  void request_arm_away();
+  void request_arm_night();
 
   void setup() override;
   void loop() override;
@@ -42,13 +67,26 @@ class ParadoxCombusComponent : public Component {
 
   void publish_alarm_state_(const std::string &value);
   void publish_zone_state_(uint8_t zone, bool open);
+  void publish_alarm_control_panel_state_(alarm_control_panel::AlarmControlPanelState state);
+
   void capture_combus_bits_();
+  void process_pending_bus_writes_();
+  void queue_write_sequence_(const std::vector<uint8_t> &sequence);
 
   InternalGPIOPin *clk_pin_{nullptr};
   InternalGPIOPin *dta_pin_{nullptr};
 
   std::array<binary_sensor::BinarySensor *, 32> zone_sensors_{};
   text_sensor::TextSensor *alarm_status_sensor_{nullptr};
+  ParadoxAlarmControlPanel *alarm_control_panel_{nullptr};
+
+  std::vector<uint8_t> disarm_sequence_{};
+  std::vector<uint8_t> arm_home_sequence_{};
+  std::vector<uint8_t> arm_away_sequence_{};
+  std::vector<uint8_t> arm_night_sequence_{};
+
+  std::deque<bool> tx_bits_{};
+  bool tx_drive_low_{false};
 
   std::string bus_message_;
   bool last_clk_state_{true};

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -19,6 +19,7 @@ components/
     __init__.py          # hub schema (`paradox_combus:`)
     binary_sensor.py     # zone entities
     text_sensor.py       # alarm status entity
+    alarm_control_panel.py # arm/disarm entity + write sequences
     paradox_combus.h     # hub implementation
     paradox_combus.cpp
 ```
@@ -55,6 +56,24 @@ text_sensor:
     type: alarm_status
     name: "Alarm Status"
 ```
+
+
+### Alarm control panel (read/write)
+
+```yaml
+alarm_control_panel:
+  - platform: paradox_combus
+    paradox_combus_id: combus
+    name: "Alarm"
+    disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    arm_home_sequence: [0x53]
+    arm_away_sequence: [0x41]
+    arm_night_sequence: [0x4E]
+```
+
+- At least one sequence is required.
+- Sequences are raw bytes transmitted LSB-first on COMBUS and are panel-specific.
+- The implementation is experimental and intended as a starting point for tuning against your panel.
 
 ## Notes
 


### PR DESCRIPTION
### Motivation
- Provide a first-pass implementation to write commands onto the Paradox COMBUS so Home Assistant can arm/disarm the alarm using ESPHome's `alarm_control_panel` integration. 
- Preserve the existing read/decoding behavior while exposing write capability as an experimental, configurable byte-sequence writer to be tuned per panel model.

### Description
- Add a new `alarm_control_panel` platform `components/paradox_combus/alarm_control_panel.py` that wires a `ParadoxAlarmControlPanel` entity to the hub and exposes YAML options `disarm_sequence`, `arm_home_sequence`, `arm_away_sequence`, and `arm_night_sequence` with validation that at least one sequence is provided. 
- Update `components/paradox_combus/__init__.py` to auto-load the `alarm_control_panel` and expose the `ParadoxAlarmControlPanel` codegen class for integration with the C++ hub. 
- Extend C++ hub (`paradox_combus.h` / `paradox_combus.cpp`) with `ParadoxAlarmControlPanel` support, configurable byte-sequence storage, methods to queue LSB-first bits, a TX bit queue (`std::deque<bool>`), `process_pending_bus_writes_()` to drive the data line in an open-collector style, and request helpers (`request_disarm`, `request_arm_*`) that enqueue sequences. 
- Publish decoded alarm states to both the existing text sensor and the new alarm control panel state entity, and update `README.md`, `docs_esphome_native_component.md`, and `alarm.yaml` with example configuration and notes that the write path is experimental and panel-specific. 

### Testing
- Successfully ran `python -m py_compile` on new/modified Python module files (`components/paradox_combus/__init__.py`, `binary_sensor.py`, `text_sensor.py`, `alarm_control_panel.py`) with no syntax errors. 
- Performed repository sanity checks and textual updates to documentation and example YAML files; C++ runtime integration and on-device behavior were not compiled/executed in this environment, so hardware validation is still required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2fbc4a94832fbb6059ff767e616d)