### PR TITLE
Require code for alarm operations and expose capability helpers

### DIFF
--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -7,8 +7,38 @@ namespace paradox_combus {
 
 static const char *const TAG = "paradox_combus";
 
+
+uint32_t ParadoxAlarmControlPanel::get_supported_features() const {
+  uint32_t features = 0;
+
+  if (this->parent_ == nullptr) {
+    return features;
+  }
+
+  if (this->parent_->supports_arm_home()) {
+    features |= 1U;
+  }
+  if (this->parent_->supports_arm_away()) {
+    features |= 1U << 1;
+  }
+  if (this->parent_->supports_arm_night()) {
+    features |= 1U << 2;
+  }
+
+  return features;
+}
+
+bool ParadoxAlarmControlPanel::get_requires_code() const { return true; }
+
+bool ParadoxAlarmControlPanel::get_requires_code_to_arm() const { return true; }
+
 void ParadoxAlarmControlPanel::control(const alarm_control_panel::AlarmControlPanelCall &call) {
   if (this->parent_ == nullptr || !call.get_state().has_value()) {
+    return;
+  }
+
+  if (!call.get_code().has_value() || call.get_code()->empty()) {
+    ESP_LOGW(TAG, "Ignoring alarm command without code");
     return;
   }
 

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -22,6 +22,9 @@ class ParadoxAlarmControlPanel : public alarm_control_panel::AlarmControlPanel {
   void set_parent(ParadoxCombusComponent *parent) { this->parent_ = parent; }
 
  protected:
+  uint32_t get_supported_features() const override;
+  bool get_requires_code() const override;
+  bool get_requires_code_to_arm() const override;
   void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
   ParadoxCombusComponent *parent_{nullptr};
 };
@@ -46,6 +49,11 @@ class ParadoxCombusComponent : public Component {
   void request_arm_home();
   void request_arm_away();
   void request_arm_night();
+
+  bool supports_disarm() const { return !this->disarm_sequence_.empty(); }
+  bool supports_arm_home() const { return !this->arm_home_sequence_.empty(); }
+  bool supports_arm_away() const { return !this->arm_away_sequence_.empty(); }
+  bool supports_arm_night() const { return !this->arm_night_sequence_.empty(); }
 
   void setup() override;
   void loop() override;


### PR DESCRIPTION
### Motivation
- The alarm control panel must implement the newer `alarm_control_panel::AlarmControlPanel` trait methods and report supported arm modes so Home Assistant can present correct actions.
- The panel should require a user code for arm and disarm operations and ignore commands that do not include a non-empty code.

### Description
- Implemented `ParadoxAlarmControlPanel::get_supported_features()` to report supported arm modes using parent capability helpers and added the method declaration in the header.
- Set `ParadoxAlarmControlPanel::get_requires_code()` and `ParadoxAlarmControlPanel::get_requires_code_to_arm()` to return `true` so the component advertises that a code is required.
- Added a code check in `ParadoxAlarmControlPanel::control()` to log a warning and ignore arm/disarm requests that lack a non-empty code.
- Added helper methods `supports_disarm()`, `supports_arm_home()`, `supports_arm_away()`, and `supports_arm_night()` to `ParadoxCombusComponent` which return true when the corresponding write sequence is configured, and exposed these in the header.
- Modified files: `components/paradox_combus/paradox_combus.cpp` and `components/paradox_combus/paradox_combus.h`.

### Testing
- Attempted to build with `pio run -e signalizacija`, but PlatformIO is not available in this environment (`bash: command not found: pio`).
- No automated unit tests were executed in this environment due to missing PlatformIO tooling, and no further automated checks were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c39c02084832f82f63edd1e2f4f33)