### PR TITLE
Make disarm sequence optional when using alarm codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,15 @@ alarm_control_panel:
     paradox_combus_id: combus
     name: "Alarm"
     disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    codes:
+      - "1234"
     arm_home_sequence: [0x53]
     arm_away_sequence: [0x41]
     arm_night_sequence: [0x4E]
 ```
+
+`codes` uses the same structure as the ESPHome template alarm control panel and is used to validate arm/disarm actions.
+If `disarm_sequence` is omitted, the entered code is sent as keypad digits for disarm.
 
 For a full multi-zone example, see `alarm-example.yaml`.
 

--- a/alarm-example.yaml
+++ b/alarm-example.yaml
@@ -98,6 +98,8 @@ alarm_control_panel:
     name: "Alarm"
     # IMPORTANT: these are example bytes and will likely need adjustment for your panel/code.
     disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    codes:
+      - "1234"
     arm_home_sequence: [0x53]
     arm_away_sequence: [0x41]
     arm_night_sequence: [0x4E]

--- a/components/paradox_combus/alarm_control_panel.py
+++ b/components/paradox_combus/alarm_control_panel.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import alarm_control_panel
-from esphome.const import CONF_ID
+from esphome.const import CONF_CODES, CONF_ID
 
 from . import ParadoxAlarmControlPanel, ParadoxCombusComponent
 
@@ -14,6 +14,13 @@ CONF_ARM_AWAY_SEQUENCE = "arm_away_sequence"
 CONF_ARM_NIGHT_SEQUENCE = "arm_night_sequence"
 
 
+def _validate_code(value):
+    value = cv.string(value)
+    if not value.isdigit():
+        raise cv.Invalid("Alarm code must contain digits only")
+    return value
+
+
 def _validate_non_empty(config):
     if not any(
         config.get(key)
@@ -22,11 +29,12 @@ def _validate_non_empty(config):
             CONF_ARM_HOME_SEQUENCE,
             CONF_ARM_AWAY_SEQUENCE,
             CONF_ARM_NIGHT_SEQUENCE,
+            CONF_CODES,
         )
     ):
         raise cv.Invalid(
-            "At least one write sequence must be configured (disarm_sequence/arm_home_sequence/"
-            "arm_away_sequence/arm_night_sequence)"
+            "At least one write/control field must be configured (disarm_sequence/arm_home_sequence/"
+            "arm_away_sequence/arm_night_sequence/codes)"
         )
     return config
 
@@ -39,6 +47,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ARM_HOME_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
             cv.Optional(CONF_ARM_AWAY_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
             cv.Optional(CONF_ARM_NIGHT_SEQUENCE): cv.ensure_list(cv.hex_uint8_t),
+            cv.Optional(CONF_CODES): cv.ensure_list(_validate_code),
         }
     ),
     _validate_non_empty,
@@ -61,3 +70,5 @@ async def to_code(config):
         cg.add(hub.set_arm_away_sequence(config[CONF_ARM_AWAY_SEQUENCE]))
     if CONF_ARM_NIGHT_SEQUENCE in config:
         cg.add(hub.set_arm_night_sequence(config[CONF_ARM_NIGHT_SEQUENCE]))
+    if CONF_CODES in config:
+        cg.add(hub.set_codes(config[CONF_CODES]))

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -28,32 +28,36 @@ uint32_t ParadoxAlarmControlPanel::get_supported_features() const {
   return features;
 }
 
-bool ParadoxAlarmControlPanel::get_requires_code() const { return true; }
+bool ParadoxAlarmControlPanel::get_requires_code() const {
+  return this->parent_ != nullptr && this->parent_->requires_code();
+}
 
-bool ParadoxAlarmControlPanel::get_requires_code_to_arm() const { return true; }
+bool ParadoxAlarmControlPanel::get_requires_code_to_arm() const {
+  return this->parent_ != nullptr && this->parent_->requires_code();
+}
 
 void ParadoxAlarmControlPanel::control(const alarm_control_panel::AlarmControlPanelCall &call) {
   if (this->parent_ == nullptr || !call.get_state().has_value()) {
     return;
   }
 
-  if (!call.get_code().has_value() || call.get_code()->empty()) {
-    ESP_LOGW(TAG, "Ignoring alarm command without code");
+  if (!this->parent_->is_valid_code(call.get_code())) {
+    ESP_LOGW(TAG, "Ignoring alarm command with invalid or missing code");
     return;
   }
 
   switch (*call.get_state()) {
     case alarm_control_panel::ACP_STATE_DISARMED:
-      this->parent_->request_disarm();
+      this->parent_->request_disarm(call.get_code());
       break;
     case alarm_control_panel::ACP_STATE_ARMED_HOME:
-      this->parent_->request_arm_home();
+      this->parent_->request_arm_home(call.get_code());
       break;
     case alarm_control_panel::ACP_STATE_ARMED_AWAY:
-      this->parent_->request_arm_away();
+      this->parent_->request_arm_away(call.get_code());
       break;
     case alarm_control_panel::ACP_STATE_ARMED_NIGHT:
-      this->parent_->request_arm_night();
+      this->parent_->request_arm_night(call.get_code());
       break;
     default:
       ESP_LOGW(TAG, "Requested alarm state is not currently mapped to COMBUS write sequence");
@@ -115,13 +119,65 @@ void ParadoxCombusComponent::queue_write_sequence_(const std::vector<uint8_t> &s
            static_cast<unsigned>(this->tx_bits_.size()));
 }
 
-void ParadoxCombusComponent::request_disarm() { this->queue_write_sequence_(this->disarm_sequence_); }
+bool ParadoxCombusComponent::is_valid_code(const optional<std::string> &code) const {
+  if (this->codes_.empty()) {
+    return true;
+  }
 
-void ParadoxCombusComponent::request_arm_home() { this->queue_write_sequence_(this->arm_home_sequence_); }
+  if (!code.has_value()) {
+    return false;
+  }
 
-void ParadoxCombusComponent::request_arm_away() { this->queue_write_sequence_(this->arm_away_sequence_); }
+  for (const auto &configured_code : this->codes_) {
+    if (configured_code == *code) {
+      return true;
+    }
+  }
 
-void ParadoxCombusComponent::request_arm_night() { this->queue_write_sequence_(this->arm_night_sequence_); }
+  return false;
+}
+
+std::vector<uint8_t> ParadoxCombusComponent::code_to_sequence_(const optional<std::string> &code) const {
+  std::vector<uint8_t> sequence;
+  if (!code.has_value()) {
+    return sequence;
+  }
+
+  for (char value : *code) {
+    if (value >= '0' && value <= '9') {
+      sequence.push_back(static_cast<uint8_t>(value));
+    }
+  }
+
+  return sequence;
+}
+
+void ParadoxCombusComponent::request_disarm(const optional<std::string> &code) {
+  if (!this->disarm_sequence_.empty()) {
+    this->queue_write_sequence_(this->disarm_sequence_);
+    return;
+  }
+
+  this->queue_write_sequence_(this->code_to_sequence_(code));
+}
+
+void ParadoxCombusComponent::request_arm_home(const optional<std::string> &code) {
+  std::vector<uint8_t> sequence = this->code_to_sequence_(code);
+  sequence.insert(sequence.end(), this->arm_home_sequence_.begin(), this->arm_home_sequence_.end());
+  this->queue_write_sequence_(sequence);
+}
+
+void ParadoxCombusComponent::request_arm_away(const optional<std::string> &code) {
+  std::vector<uint8_t> sequence = this->code_to_sequence_(code);
+  sequence.insert(sequence.end(), this->arm_away_sequence_.begin(), this->arm_away_sequence_.end());
+  this->queue_write_sequence_(sequence);
+}
+
+void ParadoxCombusComponent::request_arm_night(const optional<std::string> &code) {
+  std::vector<uint8_t> sequence = this->code_to_sequence_(code);
+  sequence.insert(sequence.end(), this->arm_night_sequence_.begin(), this->arm_night_sequence_.end());
+  this->queue_write_sequence_(sequence);
+}
 
 void ParadoxCombusComponent::process_pending_bus_writes_() {
   if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -41,19 +41,23 @@ class ParadoxCombusComponent : public Component {
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
 
   void set_disarm_sequence(const std::vector<uint8_t> &sequence) { this->disarm_sequence_ = sequence; }
+  void set_codes(const std::vector<std::string> &codes) { this->codes_ = codes; }
   void set_arm_home_sequence(const std::vector<uint8_t> &sequence) { this->arm_home_sequence_ = sequence; }
   void set_arm_away_sequence(const std::vector<uint8_t> &sequence) { this->arm_away_sequence_ = sequence; }
   void set_arm_night_sequence(const std::vector<uint8_t> &sequence) { this->arm_night_sequence_ = sequence; }
 
-  void request_disarm();
-  void request_arm_home();
-  void request_arm_away();
-  void request_arm_night();
+  void request_disarm(const optional<std::string> &code);
+  void request_arm_home(const optional<std::string> &code);
+  void request_arm_away(const optional<std::string> &code);
+  void request_arm_night(const optional<std::string> &code);
 
-  bool supports_disarm() const { return !this->disarm_sequence_.empty(); }
+  bool supports_disarm() const { return !this->disarm_sequence_.empty() || this->requires_code(); }
   bool supports_arm_home() const { return !this->arm_home_sequence_.empty(); }
   bool supports_arm_away() const { return !this->arm_away_sequence_.empty(); }
   bool supports_arm_night() const { return !this->arm_night_sequence_.empty(); }
+  bool requires_code() const { return !this->codes_.empty(); }
+  bool is_valid_code(const optional<std::string> &code) const;
+  std::vector<uint8_t> code_to_sequence_(const optional<std::string> &code) const;
 
   void setup() override;
   void loop() override;
@@ -92,6 +96,7 @@ class ParadoxCombusComponent : public Component {
   std::vector<uint8_t> arm_home_sequence_{};
   std::vector<uint8_t> arm_away_sequence_{};
   std::vector<uint8_t> arm_night_sequence_{};
+  std::vector<std::string> codes_{};
 
   std::deque<bool> tx_bits_{};
   bool tx_drive_low_{false};

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -66,12 +66,16 @@ alarm_control_panel:
     paradox_combus_id: combus
     name: "Alarm"
     disarm_sequence: [0x31, 0x32, 0x33, 0x34]
+    codes:
+      - "1234"
     arm_home_sequence: [0x53]
     arm_away_sequence: [0x41]
     arm_night_sequence: [0x4E]
 ```
 
-- At least one sequence is required.
+- At least one sequence/code config is required (`disarm_sequence`, arm sequence, and/or `codes`).
+- `codes` follows the same structure as template alarm and is used to validate both arm and disarm commands.
+- If `disarm_sequence` is omitted, the entered code is sent as keypad digits for disarm; arm modes send `code + arm_*_sequence`.
 - Sequences are raw bytes transmitted LSB-first on COMBUS and are panel-specific.
 - The implementation is experimental and intended as a starting point for tuning against your panel.
 


### PR DESCRIPTION
### Motivation
- Avoid duplicating the numeric alarm `code` as a raw hex `disarm_sequence` when the same keypad digits can be sent directly. 
- Keep `codes:` as the single source of truth for required/valid alarm codes and make arm/disarm behavior consistent with template-style codes.

### Description
- Add optional `codes:` YAML support and digit-only validation in `components/paradox_combus/alarm_control_panel.py` and wire configured codes into codegen via `cg.add(hub.set_codes(...))`.
- Expose `set_codes(...)` and store codes as `std::vector<std::string> codes_` in `components/paradox_combus/paradox_combus.h`, add `requires_code()`, `is_valid_code(...)`, and `code_to_sequence_(...)` helpers.
- Make `supports_disarm()` consider configured `codes`, validate incoming calls with `is_valid_code(...)` in `ParadoxAlarmControlPanel::control(...)`, and pass the provided `code` into `request_disarm(...)` / `request_arm_*(...)` so arm actions send `code + arm_*_sequence` and disarm falls back to sending keypad digits when `disarm_sequence` is not configured.
- Update docs and examples (`README.md`, `docs_esphome_native_component.md`, `alarm-example.yaml`) to explain that `disarm_sequence` can be omitted and that arm uses `code + arm_*_sequence` when `codes:` are used.

### Testing
- Ran `python -m compileall components/paradox_combus` and the Python component files compiled successfully.
- Ran `rg` searches to verify updated symbols and documentation references (`request_disarm(`, `code_to_sequence_`, "disarm_sequence is omitted", etc.) and found the expected matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c36593ecc832f8277e68f7974d993)