### PR TITLE
Fix paradox_combus alarm_control_panel import for current ESPHome

### DIFF
--- a/components/paradox_combus/alarm_control_panel.py
+++ b/components/paradox_combus/alarm_control_panel.py
@@ -1,13 +1,14 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import alarm_control_panel
-from esphome.const import CONF_CODES, CONF_ID
+from esphome.const import CONF_ID
 
 from . import ParadoxAlarmControlPanel, ParadoxCombusComponent
 
 DEPENDENCIES = ["paradox_combus"]
 
 CONF_PARADOX_COMBUS_ID = "paradox_combus_id"
+CONF_CODES = "codes"
 CONF_DISARM_SEQUENCE = "disarm_sequence"
 CONF_ARM_HOME_SEQUENCE = "arm_home_sequence"
 CONF_ARM_AWAY_SEQUENCE = "arm_away_sequence"


### PR DESCRIPTION
### Motivation
- The component imported `CONF_CODES` from `esphome.const`, which is not present in the target ESPHome version and caused an `ImportError` that prevented the platform from loading; the change restores compatibility by providing the constant locally.

### Description
- Stop importing `CONF_CODES` from `esphome.const` and add a local `CONF_CODES = "codes"` definition in `components/paradox_combus/alarm_control_panel.py`, keeping the existing schema and behavior unchanged.

### Testing
- Ran `python -m py_compile components/paradox_combus/alarm_control_panel.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c43fae3c8832fa3667962b47bcc5e)