### PR TITLE
Add split read/write pin support for 3-channel optocoupler wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Wiring example:
 
 ## Native ESPHome component usage
 
-This repository now includes a native ESPHome **external component** (`components/paradox_combus`) that exposes:
+This repository now includes a native ESPHome **external component** (`components/paradox_combus`) that exposes (including optional split read/write data pins for 3-channel optocoupler modules):
 
 - ESP8266/ESP32-compatible COMBUS reader implemented as a native polling loop (no timer/interrupt dependency)
 
@@ -48,7 +48,11 @@ external_components:
 paradox_combus:
   id: combus
   clk_pin: D1
-  dta_pin: D2
+  # Legacy/shared data line (single pin for read+write):
+  # dta_pin: D2
+  # 3-channel optocoupler wiring (recommended for PC817 modules):
+  read_pin: D2
+  write_pin: D3
 
 binary_sensor:
   - platform: paradox_combus

--- a/alarm-example.yaml
+++ b/alarm-example.yaml
@@ -35,7 +35,11 @@ status_led:
 paradox_combus:
   id: combus
   clk_pin: D1
-  dta_pin: D2
+  # Legacy/shared data pin:
+  # dta_pin: D2
+  # 3-channel optocoupler wiring:
+  read_pin: D2
+  write_pin: D3
 
 binary_sensor:
   - platform: paradox_combus

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -12,14 +12,35 @@ ParadoxAlarmControlPanel = paradox_combus_ns.class_("ParadoxAlarmControlPanel")
 
 CONF_CLK_PIN = "clk_pin"
 CONF_DTA_PIN = "dta_pin"
+CONF_READ_PIN = "read_pin"
+CONF_WRITE_PIN = "write_pin"
 
-CONFIG_SCHEMA = cv.Schema(
+BASE_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ParadoxCombusComponent),
         cv.Required(CONF_CLK_PIN): pins.internal_gpio_input_pin_schema,
-        cv.Required(CONF_DTA_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_DTA_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+
+def validate_config(config):
+    has_legacy_dta = CONF_DTA_PIN in config
+    has_read_pin = CONF_READ_PIN in config
+    has_write_pin = CONF_WRITE_PIN in config
+
+    if has_legacy_dta and (has_read_pin or has_write_pin):
+        raise cv.Invalid("Use either dta_pin or read_pin/write_pin, not both")
+
+    if not has_legacy_dta and not has_read_pin:
+        raise cv.Invalid("Either dta_pin or read_pin must be configured")
+
+    return config
+
+
+CONFIG_SCHEMA = cv.All(BASE_SCHEMA, validate_config)
 
 
 async def to_code(config):
@@ -29,5 +50,14 @@ async def to_code(config):
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
     cg.add(var.set_clk_pin(clk))
 
-    dta = await cg.gpio_pin_expression(config[CONF_DTA_PIN])
-    cg.add(var.set_dta_pin(dta))
+    if CONF_DTA_PIN in config:
+        dta = await cg.gpio_pin_expression(config[CONF_DTA_PIN])
+        cg.add(var.set_read_pin(dta))
+        cg.add(var.set_write_pin(dta))
+    else:
+        read_pin = await cg.gpio_pin_expression(config[CONF_READ_PIN])
+        cg.add(var.set_read_pin(read_pin))
+
+        if CONF_WRITE_PIN in config:
+            write_pin = await cg.gpio_pin_expression(config[CONF_WRITE_PIN])
+            cg.add(var.set_write_pin(write_pin))

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -70,7 +70,7 @@ void ParadoxCombusComponent::register_zone_sensor(uint8_t zone, binary_sensor::B
 }
 
 void ParadoxCombusComponent::capture_combus_bits_() {
-  if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
+  if (this->clk_pin_ == nullptr || this->read_pin_ == nullptr) {
     return;
   }
 
@@ -90,7 +90,7 @@ void ParadoxCombusComponent::capture_combus_bits_() {
 
   this->sample_pending_ = false;
 
-  this->bus_message_.push_back(this->dta_pin_->digital_read() ? '0' : '1');
+  this->bus_message_.push_back(this->read_pin_->digital_read() ? '0' : '1');
 
   if (this->bus_message_.length() > 200) {
     this->bus_message_.clear();
@@ -158,13 +158,13 @@ void ParadoxCombusComponent::request_arm_night(const optional<std::string> &code
 }
 
 void ParadoxCombusComponent::process_pending_bus_writes_() {
-  if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
+  if (this->clk_pin_ == nullptr || this->write_pin_ == nullptr) {
     return;
   }
 
   if (this->tx_bits_.empty()) {
     if (this->tx_drive_low_) {
-      this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+      this->write_pin_->pin_mode(gpio::FLAG_INPUT);
       this->tx_drive_low_ = false;
     }
     return;
@@ -177,24 +177,28 @@ void ParadoxCombusComponent::process_pending_bus_writes_() {
 
     // COMBUS uses open collector signalling: logical '1' is driven low, logical '0' is release.
     if (write_bit) {
-      this->dta_pin_->pin_mode(gpio::FLAG_OUTPUT);
-      this->dta_pin_->digital_write(false);
+      this->write_pin_->pin_mode(gpio::FLAG_OUTPUT);
+      this->write_pin_->digital_write(false);
       this->tx_drive_low_ = true;
     } else {
-      this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+      this->write_pin_->pin_mode(gpio::FLAG_INPUT);
       this->tx_drive_low_ = false;
     }
   }
 }
 
 void ParadoxCombusComponent::connect_combus_() {
-  if (this->clk_pin_ == nullptr || this->dta_pin_ == nullptr) {
-    ESP_LOGE(TAG, "clk_pin and dta_pin are required");
+  if (this->clk_pin_ == nullptr || this->read_pin_ == nullptr) {
+    ESP_LOGE(TAG, "clk_pin and read_pin are required");
     return;
   }
 
   this->clk_pin_->pin_mode(gpio::FLAG_INPUT);
-  this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+  this->read_pin_->pin_mode(gpio::FLAG_INPUT);
+  if (this->write_pin_ == nullptr) {
+    this->write_pin_ = this->read_pin_;
+  }
+  this->write_pin_->pin_mode(gpio::FLAG_INPUT);
 
   this->last_clk_state_ = this->clk_pin_->digital_read();
   this->sample_pending_ = false;
@@ -208,7 +212,9 @@ void ParadoxCombusComponent::connect_combus_() {
 void ParadoxCombusComponent::disconnect_combus_() {
   this->sample_pending_ = false;
   this->tx_bits_.clear();
-  this->dta_pin_->pin_mode(gpio::FLAG_INPUT);
+  if (this->write_pin_ != nullptr) {
+    this->write_pin_->pin_mode(gpio::FLAG_INPUT);
+  }
   this->tx_drive_low_ = false;
   this->bus_message_.clear();
   this->combus_connection_status_ = false;

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -33,7 +33,8 @@ class ParadoxZoneBinarySensor : public binary_sensor::BinarySensor {};
 class ParadoxCombusComponent : public Component {
  public:
   void set_clk_pin(InternalGPIOPin *pin) { this->clk_pin_ = pin; }
-  void set_dta_pin(InternalGPIOPin *pin) { this->dta_pin_ = pin; }
+  void set_read_pin(InternalGPIOPin *pin) { this->read_pin_ = pin; }
+  void set_write_pin(GPIOPin *pin) { this->write_pin_ = pin; }
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
@@ -81,7 +82,8 @@ class ParadoxCombusComponent : public Component {
   void queue_write_sequence_(const std::vector<uint8_t> &sequence);
 
   InternalGPIOPin *clk_pin_{nullptr};
-  InternalGPIOPin *dta_pin_{nullptr};
+  InternalGPIOPin *read_pin_{nullptr};
+  GPIOPin *write_pin_{nullptr};
 
   std::array<binary_sensor::BinarySensor *, 32> zone_sensors_{};
   ParadoxAlarmControlPanel *alarm_control_panel_{nullptr};

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -31,7 +31,11 @@ components/
 paradox_combus:
   id: combus
   clk_pin: D1
-  dta_pin: D2
+  # Legacy single data pin (shared read/write):
+  # dta_pin: D2
+  # 3-channel optocoupler (clock + read + write):
+  read_pin: D2
+  write_pin: D3
 ```
 
 ### Zone sensor
@@ -68,5 +72,5 @@ alarm_control_panel:
 ## Notes
 
 - The COMBUS parser/decoder remains based on the original implementation and now publishes directly to registered ESPHome entities.
-- Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, `dta_pin`).
+- Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, plus either legacy `dta_pin` or split `read_pin`/`write_pin`).
 - Existing sample configuration was migrated to this new format in `alarm.yaml`.


### PR DESCRIPTION
### Motivation
- Enable reliable use of 3-channel optocoupler modules (e.g. PC817) by exposing separate data `read_pin` and `write_pin` instead of a single shared `dta_pin` on the COMBUS hub.
- Preserve backwards compatibility for existing users who still rely on the legacy single `dta_pin` wiring.

### Description
- Add `read_pin` and `write_pin` YAML options and update the schema to accept either the legacy `dta_pin` or the new split-pin configuration, with validation that forbids mixing both modes (`components/paradox_combus/__init__.py`).
- Update the C++ hub to sample bus bits from `read_pin_` and drive open-collector writes via `write_pin_`, and fall back to the shared pin when only a single data pin is configured (`components/paradox_combus/paradox_combus.h` and `components/paradox_combus/paradox_combus.cpp`).
- Ensure `connect_combus_()` initializes both read and write paths and make disconnect safe when `write_pin_` is not set (`paradox_combus.cpp`).
- Refresh README, docs and example YAML to show the recommended 3-channel wiring and keep the legacy `dta_pin` commented for guidance.

### Testing
- Ran Python byte-compile check: `python -m py_compile components/paradox_combus/__init__.py components/paradox_combus/alarm_control_panel.py components/paradox_combus/binary_sensor.py`, which completed successfully.
- Performed repository-wide inspections and basic runtime-path checks via searches to verify references to `read_pin`/`write_pin` were added and `dta_pin` usage migrated (no automated unit tests present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a09147dba0832faba6159f4fcbd2a4)