### PR TITLE
paradox_combus: add frame length histogram and improved CRC/malformed diagnostics

### DIFF
--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -242,6 +242,11 @@ void ParadoxCombusComponent::connect_combus_() {
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;
   this->overflow_drop_frames_ = 0;
+  this->frame_len_hist_.fill(0);
+  this->short_frame_drops_ = 0;
+  this->malformed_d1_d0_frames_ = 0;
+  this->last_crc_fail_preview_.clear();
+  this->last_crc_fail_cmd_ = 0;
   this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
@@ -318,6 +323,19 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
              static_cast<unsigned>(this->clock_falling_edges_), static_cast<unsigned>(this->sampled_bits_),
              static_cast<unsigned>(this->decoded_frames_), static_cast<unsigned>(this->crc_drop_frames_),
              static_cast<unsigned>(this->overflow_drop_frames_), static_cast<unsigned>(this->tx_bits_.size()));
+
+    ESP_LOGD(TAG,
+             "COMBUS frame lens (5s): <=8=%u 9-16=%u 17-32=%u 33-64=%u 65-96=%u 97-128=%u 129-160=%u >160=%u "
+             "short_drop=%u malformed_d0d1=%u",
+             static_cast<unsigned>(this->frame_len_hist_[0]), static_cast<unsigned>(this->frame_len_hist_[1]),
+             static_cast<unsigned>(this->frame_len_hist_[2]), static_cast<unsigned>(this->frame_len_hist_[3]),
+             static_cast<unsigned>(this->frame_len_hist_[4]), static_cast<unsigned>(this->frame_len_hist_[5]),
+             static_cast<unsigned>(this->frame_len_hist_[6]), static_cast<unsigned>(this->frame_len_hist_[7]),
+             static_cast<unsigned>(this->short_frame_drops_), static_cast<unsigned>(this->malformed_d1_d0_frames_));
+
+    if (!this->last_crc_fail_preview_.empty()) {
+      ESP_LOGD(TAG, "Last CRC fail cmd=0x%02X bits=%s", this->last_crc_fail_cmd_, this->last_crc_fail_preview_.c_str());
+    }
   }
 
   this->clock_falling_edges_ = 0;
@@ -325,6 +343,29 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;
   this->overflow_drop_frames_ = 0;
+  this->frame_len_hist_.fill(0);
+  this->short_frame_drops_ = 0;
+  this->malformed_d1_d0_frames_ = 0;
+}
+
+void ParadoxCombusComponent::track_frame_length_(size_t frame_bits) {
+  if (frame_bits <= 8) {
+    this->frame_len_hist_[0]++;
+  } else if (frame_bits <= 16) {
+    this->frame_len_hist_[1]++;
+  } else if (frame_bits <= 32) {
+    this->frame_len_hist_[2]++;
+  } else if (frame_bits <= 64) {
+    this->frame_len_hist_[3]++;
+  } else if (frame_bits <= 96) {
+    this->frame_len_hist_[4]++;
+  } else if (frame_bits <= 128) {
+    this->frame_len_hist_[5]++;
+  } else if (frame_bits <= 160) {
+    this->frame_len_hist_[6]++;
+  } else {
+    this->frame_len_hist_[7]++;
+  }
 }
 
 void ParadoxCombusComponent::process_zone_status_(const std::string &msg) {
@@ -367,7 +408,10 @@ void ParadoxCombusComponent::process_alarm_status_(const std::string &msg) {
 }
 
 void ParadoxCombusComponent::decode_message_(std::string &msg) {
+  this->track_frame_length_(msg.length());
+
   if (msg.length() < 8) {
+    this->short_frame_drops_++;
     return;
   }
 
@@ -377,15 +421,25 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
            format_bits_preview(msg).c_str());
 
   if (cmd == 0xD0 || cmd == 0xD1) {
+    if (msg.length() <= ((4 * 8) + 1)) {
+      this->malformed_d1_d0_frames_++;
+      ESP_LOGD(TAG, "RX frame dropped: cmd 0x%02X too short for postamble trim (%u bits)", cmd,
+               static_cast<unsigned>(msg.length()));
+      return;
+    }
     msg = msg.substr(0, msg.length() - (4 * 8) - 1);
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
+      this->last_crc_fail_cmd_ = cmd;
+      this->last_crc_fail_preview_ = format_bits_preview(msg);
       ESP_LOGD(TAG, "RX frame dropped: CRC mismatch for cmd 0x%02X", cmd);
       return;
     }
   } else {
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
+      this->last_crc_fail_cmd_ = cmd;
+      this->last_crc_fail_preview_ = format_bits_preview(msg);
       ESP_LOGD(TAG, "RX frame dropped: CRC mismatch for cmd 0x%02X", cmd);
       return;
     }

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -81,6 +81,7 @@ class ParadoxCombusComponent : public Component {
   void process_pending_bus_writes_();
   void queue_write_sequence_(const std::vector<uint8_t> &sequence);
   void log_bus_diagnostics_();
+  void track_frame_length_(size_t frame_bits);
 
   InternalGPIOPin *clk_pin_{nullptr};
   InternalGPIOPin *read_pin_{nullptr};
@@ -107,6 +108,11 @@ class ParadoxCombusComponent : public Component {
   uint32_t decoded_frames_{0};
   uint32_t crc_drop_frames_{0};
   uint32_t overflow_drop_frames_{0};
+  std::array<uint32_t, 8> frame_len_hist_{};
+  uint32_t short_frame_drops_{0};
+  uint32_t malformed_d1_d0_frames_{0};
+  std::string last_crc_fail_preview_;
+  uint8_t last_crc_fail_cmd_{0};
   bool combus_connection_status_{false};
 
 };


### PR DESCRIPTION
### Motivation

- Improve runtime diagnostics for COMBUS frames by tracking frame length distributions and capturing more context on CRC and malformed-frame drops.
- Provide visibility into short frames and D0/D1-specific malformed cases to aid debugging flaky wiring or protocol issues.

### Description

- Add `frame_len_hist_`, `short_frame_drops_`, `malformed_d1_d0_frames_`, `last_crc_fail_preview_`, and `last_crc_fail_cmd_` members and initialize/clear them in `connect_combus_` and `log_bus_diagnostics_`. 
- Introduce `track_frame_length_(size_t)` to bucket frame sizes and call it from `decode_message_`. 
- Increment `short_frame_drops_` for frames shorter than 8 bits and increment `malformed_d1_d0_frames_` for too-short `0xD0`/`0xD1` frames; store failing command and a preview when CRC checks fail in `last_crc_fail_*`. 
- Extend diagnostic logging in `log_bus_diagnostics_` to include the frame length histogram, short/malformed drop counts, and the last CRC-fail preview string.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d02558e4832fa59720d58b3dd431)