### PR TITLE
paradox_combus: add `frame_idle_us` config and improved frame diagnostics/handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ external_components:
 paradox_combus:
   id: combus
   clk_pin: D1
+  # Optional: frame split idle timeout (microseconds).
+  # Increase if logs show mostly very short frames (<=8 bits).
+  frame_idle_us: 25000
   # Legacy/shared data line (single pin for read+write):
   # dta_pin: D2
   # 3-channel optocoupler wiring (recommended for PC817 modules):

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -14,6 +14,7 @@ CONF_CLK_PIN = "clk_pin"
 CONF_DTA_PIN = "dta_pin"
 CONF_READ_PIN = "read_pin"
 CONF_WRITE_PIN = "write_pin"
+CONF_FRAME_IDLE_US = "frame_idle_us"
 
 BASE_SCHEMA = cv.Schema(
     {
@@ -22,6 +23,7 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_DTA_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_FRAME_IDLE_US, default=25000): cv.int_range(min=2000, max=200000),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -49,6 +51,7 @@ async def to_code(config):
 
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
     cg.add(var.set_clk_pin(clk))
+    cg.add(var.set_frame_idle_us(config[CONF_FRAME_IDLE_US]))
 
     if CONF_DTA_PIN in config:
         dta = await cg.gpio_pin_expression(config[CONF_DTA_PIN])

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -242,10 +242,15 @@ void ParadoxCombusComponent::connect_combus_() {
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;
   this->overflow_drop_frames_ = 0;
+  this->frame_len_hist_.fill(0);
+  this->short_frame_drops_ = 0;
+  this->malformed_d1_d0_frames_ = 0;
+  this->last_crc_fail_preview_.clear();
+  this->last_crc_fail_cmd_ = 0;
   this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
-  ESP_LOGI(TAG, "COMBUS initialized in polling mode");
+  ESP_LOGI(TAG, "COMBUS initialized in polling mode (frame_idle_us=%u)", static_cast<unsigned>(this->frame_idle_us_));
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {
@@ -318,6 +323,19 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
              static_cast<unsigned>(this->clock_falling_edges_), static_cast<unsigned>(this->sampled_bits_),
              static_cast<unsigned>(this->decoded_frames_), static_cast<unsigned>(this->crc_drop_frames_),
              static_cast<unsigned>(this->overflow_drop_frames_), static_cast<unsigned>(this->tx_bits_.size()));
+
+    ESP_LOGD(TAG,
+             "COMBUS frame lens (5s): <=8=%u 9-16=%u 17-32=%u 33-64=%u 65-96=%u 97-128=%u 129-160=%u >160=%u "
+             "short_drop=%u malformed_d0d1=%u",
+             static_cast<unsigned>(this->frame_len_hist_[0]), static_cast<unsigned>(this->frame_len_hist_[1]),
+             static_cast<unsigned>(this->frame_len_hist_[2]), static_cast<unsigned>(this->frame_len_hist_[3]),
+             static_cast<unsigned>(this->frame_len_hist_[4]), static_cast<unsigned>(this->frame_len_hist_[5]),
+             static_cast<unsigned>(this->frame_len_hist_[6]), static_cast<unsigned>(this->frame_len_hist_[7]),
+             static_cast<unsigned>(this->short_frame_drops_), static_cast<unsigned>(this->malformed_d1_d0_frames_));
+
+    if (!this->last_crc_fail_preview_.empty()) {
+      ESP_LOGD(TAG, "Last CRC fail cmd=0x%02X bits=%s", this->last_crc_fail_cmd_, this->last_crc_fail_preview_.c_str());
+    }
   }
 
   this->clock_falling_edges_ = 0;
@@ -325,6 +343,29 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;
   this->overflow_drop_frames_ = 0;
+  this->frame_len_hist_.fill(0);
+  this->short_frame_drops_ = 0;
+  this->malformed_d1_d0_frames_ = 0;
+}
+
+void ParadoxCombusComponent::track_frame_length_(size_t frame_bits) {
+  if (frame_bits <= 8) {
+    this->frame_len_hist_[0]++;
+  } else if (frame_bits <= 16) {
+    this->frame_len_hist_[1]++;
+  } else if (frame_bits <= 32) {
+    this->frame_len_hist_[2]++;
+  } else if (frame_bits <= 64) {
+    this->frame_len_hist_[3]++;
+  } else if (frame_bits <= 96) {
+    this->frame_len_hist_[4]++;
+  } else if (frame_bits <= 128) {
+    this->frame_len_hist_[5]++;
+  } else if (frame_bits <= 160) {
+    this->frame_len_hist_[6]++;
+  } else {
+    this->frame_len_hist_[7]++;
+  }
 }
 
 void ParadoxCombusComponent::process_zone_status_(const std::string &msg) {
@@ -367,7 +408,10 @@ void ParadoxCombusComponent::process_alarm_status_(const std::string &msg) {
 }
 
 void ParadoxCombusComponent::decode_message_(std::string &msg) {
+  this->track_frame_length_(msg.length());
+
   if (msg.length() < 8) {
+    this->short_frame_drops_++;
     return;
   }
 
@@ -377,15 +421,25 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
            format_bits_preview(msg).c_str());
 
   if (cmd == 0xD0 || cmd == 0xD1) {
+    if (msg.length() <= ((4 * 8) + 1)) {
+      this->malformed_d1_d0_frames_++;
+      ESP_LOGD(TAG, "RX frame dropped: cmd 0x%02X too short for postamble trim (%u bits)", cmd,
+               static_cast<unsigned>(msg.length()));
+      return;
+    }
     msg = msg.substr(0, msg.length() - (4 * 8) - 1);
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
+      this->last_crc_fail_cmd_ = cmd;
+      this->last_crc_fail_preview_ = format_bits_preview(msg);
       ESP_LOGD(TAG, "RX frame dropped: CRC mismatch for cmd 0x%02X", cmd);
       return;
     }
   } else {
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
+      this->last_crc_fail_cmd_ = cmd;
+      this->last_crc_fail_preview_ = format_bits_preview(msg);
       ESP_LOGD(TAG, "RX frame dropped: CRC mismatch for cmd 0x%02X", cmd);
       return;
     }
@@ -440,7 +494,7 @@ bool ParadoxCombusComponent::check_clock_idle_() {
   unsigned long current_micros = micros();
   long idletime = (current_micros - this->last_clk_signal_);
 
-  if (idletime > 8000) {
+  if (idletime > static_cast<long>(this->frame_idle_us_)) {
     return true;
   } else {
     return false;

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -35,6 +35,7 @@ class ParadoxCombusComponent : public Component {
   void set_clk_pin(InternalGPIOPin *pin) { this->clk_pin_ = pin; }
   void set_read_pin(InternalGPIOPin *pin) { this->read_pin_ = pin; }
   void set_write_pin(GPIOPin *pin) { this->write_pin_ = pin; }
+  void set_frame_idle_us(uint32_t frame_idle_us) { this->frame_idle_us_ = frame_idle_us; }
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
@@ -81,6 +82,7 @@ class ParadoxCombusComponent : public Component {
   void process_pending_bus_writes_();
   void queue_write_sequence_(const std::vector<uint8_t> &sequence);
   void log_bus_diagnostics_();
+  void track_frame_length_(size_t frame_bits);
 
   InternalGPIOPin *clk_pin_{nullptr};
   InternalGPIOPin *read_pin_{nullptr};
@@ -107,6 +109,12 @@ class ParadoxCombusComponent : public Component {
   uint32_t decoded_frames_{0};
   uint32_t crc_drop_frames_{0};
   uint32_t overflow_drop_frames_{0};
+  std::array<uint32_t, 8> frame_len_hist_{};
+  uint32_t short_frame_drops_{0};
+  uint32_t malformed_d1_d0_frames_{0};
+  std::string last_crc_fail_preview_;
+  uint8_t last_crc_fail_cmd_{0};
+  uint32_t frame_idle_us_{25000};
   bool combus_connection_status_{false};
 
 };

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -31,6 +31,8 @@ components/
 paradox_combus:
   id: combus
   clk_pin: D1
+  # Optional frame boundary idle timeout in microseconds.
+  frame_idle_us: 25000
   # Legacy single data pin (shared read/write):
   # dta_pin: D2
   # 3-channel optocoupler (clock + read + write):


### PR DESCRIPTION
### Motivation

- Provide a configurable frame boundary idle timeout to better detect frame boundaries on varied optocoupler/clock conditions.
- Improve runtime diagnostics to understand incoming frame length distribution and CRC failures for easier troubleshooting of noisy/fast buses.
- Reduce false positives from very short or malformed frames (particularly for `0xD0`/`0xD1` frames) by dropping them explicitly and counting occurrences.

### Description

- Add a new hub option `frame_idle_us` (default `25000`, validated range `2000..200000`) to the Python schema and expose it via `set_frame_idle_us` in the component header and `to_code` binding. 
- Use `frame_idle_us_` in `check_clock_idle_()` for configurable idle detection instead of the hardcoded `8000` microseconds. 
- Add frame length tracking (`frame_len_hist_`) and counters (`short_frame_drops_`, `malformed_d1_d0_frames_`) plus last CRC-fail preview (`last_crc_fail_preview_`, `last_crc_fail_cmd_`) and include these metrics in debug diagnostic logs. 
- Improve `decode_message_()` to record frame lengths, drop very short frames, trim and validate `0xD0`/`0xD1` postamble frames more defensively, and record CRC failure previews for debugging. 
- Update `README.md` and `docs_esphome_native_component.md` YAML examples and documentation to document the new `frame_idle_us` option and show the default value.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0d02558e4832fa59720d58b3dd431)