### PR TITLE
COMBUS: add sample_delay_us & invert_data, drop misaligned frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ paradox_combus:
   # Optional: frame split idle timeout (microseconds).
   # Increase if logs show mostly very short frames (<=8 bits).
   frame_idle_us: 25000
+  # Optional: sampling delay after each falling clock edge (40..250 us).
+  sample_delay_us: 150
+  # Optional: invert read polarity for troubleshooting optocoupler/wiring polarity.
+  invert_data: false
   # Legacy/shared data line (single pin for read+write):
   # dta_pin: D2
   # 3-channel optocoupler wiring (recommended for PC817 modules):

--- a/alarm-example.yaml
+++ b/alarm-example.yaml
@@ -40,6 +40,8 @@ paradox_combus:
   # 3-channel optocoupler wiring:
   read_pin: D2
   write_pin: D3
+  sample_delay_us: 150
+  invert_data: false
 
 binary_sensor:
   - platform: paradox_combus

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -15,6 +15,8 @@ CONF_DTA_PIN = "dta_pin"
 CONF_READ_PIN = "read_pin"
 CONF_WRITE_PIN = "write_pin"
 CONF_FRAME_IDLE_US = "frame_idle_us"
+CONF_SAMPLE_DELAY_US = "sample_delay_us"
+CONF_INVERT_DATA = "invert_data"
 
 BASE_SCHEMA = cv.Schema(
     {
@@ -24,6 +26,8 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
         cv.Optional(CONF_FRAME_IDLE_US, default=25000): cv.int_range(min=2000, max=200000),
+        cv.Optional(CONF_SAMPLE_DELAY_US, default=150): cv.int_range(min=40, max=250),
+        cv.Optional(CONF_INVERT_DATA, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -52,6 +56,8 @@ async def to_code(config):
     clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
     cg.add(var.set_clk_pin(clk))
     cg.add(var.set_frame_idle_us(config[CONF_FRAME_IDLE_US]))
+    cg.add(var.set_sample_delay_us(config[CONF_SAMPLE_DELAY_US]))
+    cg.add(var.set_invert_data(config[CONF_INVERT_DATA]))
 
     if CONF_DTA_PIN in config:
         dta = await cg.gpio_pin_expression(config[CONF_DTA_PIN])

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -108,7 +108,7 @@ void ParadoxCombusComponent::capture_combus_bits_() {
 
   if (this->last_clk_state_ && !clk_state) {
     this->last_clk_signal_ = now;
-    this->pending_sample_at_ = now + 150;
+    this->pending_sample_at_ = now + this->sample_delay_us_;
     this->sample_pending_ = true;
     this->clock_falling_edges_++;
   }
@@ -121,7 +121,9 @@ void ParadoxCombusComponent::capture_combus_bits_() {
   this->sample_pending_ = false;
   this->sampled_bits_++;
 
-  this->bus_message_.push_back(this->read_pin_->digital_read() ? '0' : '1');
+  const bool raw_level = this->read_pin_->digital_read();
+  const bool bit_is_one = this->invert_data_ ? raw_level : !raw_level;
+  this->bus_message_.push_back(bit_is_one ? '1' : '0');
 
   if (this->bus_message_.length() > 200) {
     this->bus_message_.clear();
@@ -245,12 +247,15 @@ void ParadoxCombusComponent::connect_combus_() {
   this->frame_len_hist_.fill(0);
   this->short_frame_drops_ = 0;
   this->malformed_d1_d0_frames_ = 0;
+  this->misaligned_frame_drops_ = 0;
   this->last_crc_fail_preview_.clear();
   this->last_crc_fail_cmd_ = 0;
   this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
-  ESP_LOGI(TAG, "COMBUS initialized in polling mode (frame_idle_us=%u)", static_cast<unsigned>(this->frame_idle_us_));
+  ESP_LOGI(TAG, "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, invert_data=%s)",
+           static_cast<unsigned>(this->frame_idle_us_), static_cast<unsigned>(this->sample_delay_us_),
+           YESNO(this->invert_data_));
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {
@@ -326,12 +331,13 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
 
     ESP_LOGD(TAG,
              "COMBUS frame lens (5s): <=8=%u 9-16=%u 17-32=%u 33-64=%u 65-96=%u 97-128=%u 129-160=%u >160=%u "
-             "short_drop=%u malformed_d0d1=%u",
+             "short_drop=%u malformed_d0d1=%u misaligned=%u",
              static_cast<unsigned>(this->frame_len_hist_[0]), static_cast<unsigned>(this->frame_len_hist_[1]),
              static_cast<unsigned>(this->frame_len_hist_[2]), static_cast<unsigned>(this->frame_len_hist_[3]),
              static_cast<unsigned>(this->frame_len_hist_[4]), static_cast<unsigned>(this->frame_len_hist_[5]),
              static_cast<unsigned>(this->frame_len_hist_[6]), static_cast<unsigned>(this->frame_len_hist_[7]),
-             static_cast<unsigned>(this->short_frame_drops_), static_cast<unsigned>(this->malformed_d1_d0_frames_));
+             static_cast<unsigned>(this->short_frame_drops_), static_cast<unsigned>(this->malformed_d1_d0_frames_),
+             static_cast<unsigned>(this->misaligned_frame_drops_));
 
     if (!this->last_crc_fail_preview_.empty()) {
       ESP_LOGD(TAG, "Last CRC fail cmd=0x%02X bits=%s", this->last_crc_fail_cmd_, this->last_crc_fail_preview_.c_str());
@@ -346,6 +352,7 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
   this->frame_len_hist_.fill(0);
   this->short_frame_drops_ = 0;
   this->malformed_d1_d0_frames_ = 0;
+  this->misaligned_frame_drops_ = 0;
 }
 
 void ParadoxCombusComponent::track_frame_length_(size_t frame_bits) {
@@ -428,6 +435,12 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
       return;
     }
     msg = msg.substr(0, msg.length() - (4 * 8) - 1);
+    if ((msg.length() % 8) != 0) {
+      this->misaligned_frame_drops_++;
+      ESP_LOGD(TAG, "RX frame dropped: bit length not byte-aligned after postamble trim (%u bits, cmd=0x%02X)",
+               static_cast<unsigned>(msg.length()), cmd);
+      return;
+    }
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
       this->last_crc_fail_cmd_ = cmd;
@@ -436,6 +449,12 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
       return;
     }
   } else {
+    if ((msg.length() % 8) != 0) {
+      this->misaligned_frame_drops_++;
+      ESP_LOGD(TAG, "RX frame dropped: bit length not byte-aligned (%u bits, cmd=0x%02X)",
+               static_cast<unsigned>(msg.length()), cmd);
+      return;
+    }
     if (!check_crc_(msg)) {
       this->crc_drop_frames_++;
       this->last_crc_fail_cmd_ = cmd;

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -36,6 +36,8 @@ class ParadoxCombusComponent : public Component {
   void set_read_pin(InternalGPIOPin *pin) { this->read_pin_ = pin; }
   void set_write_pin(GPIOPin *pin) { this->write_pin_ = pin; }
   void set_frame_idle_us(uint32_t frame_idle_us) { this->frame_idle_us_ = frame_idle_us; }
+  void set_sample_delay_us(uint32_t sample_delay_us) { this->sample_delay_us_ = sample_delay_us; }
+  void set_invert_data(bool invert_data) { this->invert_data_ = invert_data; }
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
@@ -115,6 +117,9 @@ class ParadoxCombusComponent : public Component {
   std::string last_crc_fail_preview_;
   uint8_t last_crc_fail_cmd_{0};
   uint32_t frame_idle_us_{25000};
+  uint32_t sample_delay_us_{150};
+  uint32_t misaligned_frame_drops_{0};
+  bool invert_data_{false};
   bool combus_connection_status_{false};
 
 };

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -33,6 +33,10 @@ paradox_combus:
   clk_pin: D1
   # Optional frame boundary idle timeout in microseconds.
   frame_idle_us: 25000
+  # Optional sample delay after each falling clock edge (40..250 us).
+  sample_delay_us: 150
+  # Optional data polarity inversion for read sampling.
+  invert_data: false
   # Legacy single data pin (shared read/write):
   # dta_pin: D2
   # 3-channel optocoupler (clock + read + write):


### PR DESCRIPTION
### Motivation
- Provide runtime tuning for the COMBUS sampling point instead of a fixed 150µs delay to help match different optocouplers/wiring and reduce decoding noise. 
- Allow inverting sampled data polarity to quickly test signal polarity issues without changing hardware.
- Prevent misleading CRC "decoded" frames caused by bitstreams that are not byte-aligned by enforcing strict byte-alignment before CRC checks.

### Description
- Add two new YAML options to the hub schema: `sample_delay_us` (range `40..250`, default `150`) and `invert_data` (boolean, default `false`) and wire them through `to_code()` to the native component via `set_sample_delay_us` and `set_invert_data`.
- Replace the fixed 150µs sampling offset with the configurable `sample_delay_us` in the capture path and apply `invert_data` when converting raw pin level to bus bits.
- Enforce strict byte-alignment (`msg.length() % 8 != 0`) before performing CRC checks, applying the postamble trim for `0xD0/0xD1` frames first and then checking alignment; misaligned frames are now dropped and counted.
- Add a `misaligned` counter to diagnostics and include it in the periodic COMBUS diagnostic log output, and update README/docs/example YAML to document the new options and defaults.

### Testing
- Ran `python -m compileall components/paradox_combus` and the Python components compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0dfe01bf8832fa0777e50d86734e3)