### PR TITLE
paradox_combus: recover misaligned frames and warn on low clock activity

### DIFF
--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -318,6 +318,7 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
   }
 
   this->last_diag_log_at_ = now;
+  const float edges_per_second = this->clock_falling_edges_ / 5.0f;
   if (this->clock_falling_edges_ == 0) {
     ESP_LOGW(TAG,
              "No COMBUS clock edges seen in last 5s (clk=%d read=%d). Check wiring/level-shifting/opto speed.",
@@ -341,6 +342,14 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
 
     if (!this->last_crc_fail_preview_.empty()) {
       ESP_LOGD(TAG, "Last CRC fail cmd=0x%02X bits=%s", this->last_crc_fail_cmd_, this->last_crc_fail_preview_.c_str());
+    }
+
+    if (edges_per_second < 100.0f) {
+      ESP_LOGW(TAG,
+               "Very low COMBUS clock activity detected (%.1f falling edges/sec). "
+               "This usually indicates wiring/level-shifting/sampling issues. "
+               "Try invert_data, reduce sample_delay_us, and verify optocoupler speed.",
+               edges_per_second);
     }
   }
 
@@ -373,6 +382,36 @@ void ParadoxCombusComponent::track_frame_length_(size_t frame_bits) {
   } else {
     this->frame_len_hist_[7]++;
   }
+}
+
+bool ParadoxCombusComponent::recover_byte_alignment_(std::string &msg, int cmd, bool trim_postamble) {
+  const size_t original_length = msg.length();
+  for (size_t trim_bits = 1; trim_bits <= 7; trim_bits++) {
+    if (original_length <= trim_bits) {
+      break;
+    }
+
+    std::string candidate = msg.substr(0, original_length - trim_bits);
+    if (trim_postamble) {
+      if (candidate.length() <= ((4 * 8) + 1)) {
+        continue;
+      }
+      candidate = candidate.substr(0, candidate.length() - (4 * 8) - 1);
+    }
+
+    if ((candidate.length() % 8) != 0 || !this->check_crc_(candidate)) {
+      continue;
+    }
+
+    ESP_LOGD(TAG,
+             "RX frame recovered: trimmed %u trailing bit(s) to restore byte alignment (cmd=0x%02X, %u -> %u bits)",
+             static_cast<unsigned>(trim_bits), cmd, static_cast<unsigned>(original_length),
+             static_cast<unsigned>(msg.length() - trim_bits));
+    msg.resize(original_length - trim_bits);
+    return true;
+  }
+
+  return false;
 }
 
 void ParadoxCombusComponent::process_zone_status_(const std::string &msg) {
@@ -417,7 +456,9 @@ void ParadoxCombusComponent::process_alarm_status_(const std::string &msg) {
 void ParadoxCombusComponent::decode_message_(std::string &msg) {
   this->track_frame_length_(msg.length());
 
-  if (msg.length() < 8) {
+  // A valid COMBUS packet must contain at least one payload byte plus one CRC byte.
+  // Shorter captures are almost always split/noise artifacts and should be dropped early.
+  if (msg.length() < 16) {
     this->short_frame_drops_++;
     return;
   }
@@ -428,6 +469,13 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
            format_bits_preview(msg).c_str());
 
   if (cmd == 0xD0 || cmd == 0xD1) {
+    if ((msg.length() % 8) != 0 && !this->recover_byte_alignment_(msg, cmd, true)) {
+      this->misaligned_frame_drops_++;
+      ESP_LOGD(TAG, "RX frame dropped: bit length not byte-aligned (cmd=0x%02X, %u bits)", cmd,
+               static_cast<unsigned>(msg.length()));
+      return;
+    }
+
     if (msg.length() <= ((4 * 8) + 1)) {
       this->malformed_d1_d0_frames_++;
       ESP_LOGD(TAG, "RX frame dropped: cmd 0x%02X too short for postamble trim (%u bits)", cmd,
@@ -449,7 +497,7 @@ void ParadoxCombusComponent::decode_message_(std::string &msg) {
       return;
     }
   } else {
-    if ((msg.length() % 8) != 0) {
+    if ((msg.length() % 8) != 0 && !this->recover_byte_alignment_(msg, cmd, false)) {
       this->misaligned_frame_drops_++;
       ESP_LOGD(TAG, "RX frame dropped: bit length not byte-aligned (%u bits, cmd=0x%02X)",
                static_cast<unsigned>(msg.length()), cmd);

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -85,6 +85,7 @@ class ParadoxCombusComponent : public Component {
   void queue_write_sequence_(const std::vector<uint8_t> &sequence);
   void log_bus_diagnostics_();
   void track_frame_length_(size_t frame_bits);
+  bool recover_byte_alignment_(std::string &msg, int cmd, bool trim_postamble);
 
   InternalGPIOPin *clk_pin_{nullptr};
   InternalGPIOPin *read_pin_{nullptr};

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -78,5 +78,8 @@ alarm_control_panel:
 ## Notes
 
 - The COMBUS parser/decoder remains based on the original implementation and now publishes directly to registered ESPHome entities.
+- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000` and `sample_delay_us: 150`.
+  Values like `frame_idle_us: 150000` can merge multiple packets into one frame and will usually prevent decoding.
+- If diagnostics show very low clock activity (for example tens of edges/sec), decoding will fail regardless of CRC/frame tuning; this usually points to wiring, pull-up, level-shifting, or optocoupler speed limits.
 - Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, plus either legacy `dta_pin` or split `read_pin`/`write_pin`).
 - Existing sample configuration was migrated to this new format in `alarm.yaml`.


### PR DESCRIPTION
### Motivation

- Improve robustness of the COMBUS decoder by recovering common byte-alignment/capture truncation issues and by surfacing very low clock activity during diagnostics.
- Reduce noisy short-frame processing by rejecting obviously too-short captures earlier.

### Description

- Increase minimum packet acceptance from `8` to `16` bits and drop short/noise captures earlier in `decode_message_`.
- Add `recover_byte_alignment_` which attempts trimming `1..7` trailing bits (and optionally the D0/D1 postamble) to restore byte alignment and a valid CRC, and invoke it from `decode_message_` for misaligned frames.
- Add a diagnostic warning in `log_bus_diagnostics_` that computes falling edges/sec and logs a warning when activity is very low (threshold `100` edges/sec) with guidance to check wiring/level-shifting/sampling.
- Expose the recovery helper in the header and update `docs_esphome_native_component.md` with troubleshooting tips for `bit length not byte-aligned`, `CRC mismatch` drops, and low clock activity.

### Testing

- Compiled the modified component in the ESPHome/PlatformIO build environment and the project builds successfully.
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a132986044832fb0e4d3ecb72f095f)