### PR TITLE
Add configurable sampling phase and widen COMBUS sample-delay tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ paradox_combus:
   # Optional: frame split idle timeout (microseconds).
   # Increase if logs show mostly very short frames (<=8 bits).
   frame_idle_us: 25000
-  # Optional: sampling delay after each falling clock edge (40..250 us).
-  sample_delay_us: 150
+  # Optional: sampling delay after selected clock edge (40..900 us).
+  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
+  sample_delay_us: 350
+  # Sample on rising edge for slave->master packets (default).
+  # Set false to sample after falling edge if your wiring inverts bus phases.
+  sample_on_rising: true
   # Optional: invert read polarity for troubleshooting optocoupler/wiring polarity.
   invert_data: false
   # Legacy/shared data line (single pin for read+write):

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -17,6 +17,7 @@ CONF_WRITE_PIN = "write_pin"
 CONF_FRAME_IDLE_US = "frame_idle_us"
 CONF_SAMPLE_DELAY_US = "sample_delay_us"
 CONF_INVERT_DATA = "invert_data"
+CONF_SAMPLE_ON_RISING = "sample_on_rising"
 
 BASE_SCHEMA = cv.Schema(
     {
@@ -26,7 +27,8 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
         cv.Optional(CONF_FRAME_IDLE_US, default=25000): cv.int_range(min=2000, max=200000),
-        cv.Optional(CONF_SAMPLE_DELAY_US, default=150): cv.int_range(min=40, max=250),
+        cv.Optional(CONF_SAMPLE_DELAY_US, default=350): cv.int_range(min=40, max=900),
+        cv.Optional(CONF_SAMPLE_ON_RISING, default=True): cv.boolean,
         cv.Optional(CONF_INVERT_DATA, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -57,6 +59,7 @@ async def to_code(config):
     cg.add(var.set_clk_pin(clk))
     cg.add(var.set_frame_idle_us(config[CONF_FRAME_IDLE_US]))
     cg.add(var.set_sample_delay_us(config[CONF_SAMPLE_DELAY_US]))
+    cg.add(var.set_sample_on_rising(config[CONF_SAMPLE_ON_RISING]))
     cg.add(var.set_invert_data(config[CONF_INVERT_DATA]))
 
     if CONF_DTA_PIN in config:

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -105,13 +105,19 @@ void ParadoxCombusComponent::capture_combus_bits_() {
 
   const unsigned long now = micros();
   const bool clk_state = this->clk_pin_->digital_read();
+  const bool clk_rising = !this->last_clk_state_ && clk_state;
+  const bool clk_falling = this->last_clk_state_ && !clk_state;
 
-  if (this->last_clk_state_ && !clk_state) {
+  if (clk_falling) {
     this->last_clk_signal_ = now;
-    this->pending_sample_at_ = now + this->sample_delay_us_;
-    this->sample_pending_ = true;
     this->clock_falling_edges_++;
   }
+
+  if ((this->sample_on_rising_ && clk_rising) || (!this->sample_on_rising_ && clk_falling)) {
+    this->pending_sample_at_ = now + this->sample_delay_us_;
+    this->sample_pending_ = true;
+  }
+
   this->last_clk_state_ = clk_state;
 
   if (!this->sample_pending_ || static_cast<long>(now - this->pending_sample_at_) < 0) {
@@ -253,9 +259,11 @@ void ParadoxCombusComponent::connect_combus_() {
   this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
-  ESP_LOGI(TAG, "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, invert_data=%s)",
+  ESP_LOGI(TAG,
+           "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, sample_on_rising=%s, "
+           "invert_data=%s)",
            static_cast<unsigned>(this->frame_idle_us_), static_cast<unsigned>(this->sample_delay_us_),
-           YESNO(this->invert_data_));
+           YESNO(this->sample_on_rising_), YESNO(this->invert_data_));
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -38,6 +38,7 @@ class ParadoxCombusComponent : public Component {
   void set_frame_idle_us(uint32_t frame_idle_us) { this->frame_idle_us_ = frame_idle_us; }
   void set_sample_delay_us(uint32_t sample_delay_us) { this->sample_delay_us_ = sample_delay_us; }
   void set_invert_data(bool invert_data) { this->invert_data_ = invert_data; }
+  void set_sample_on_rising(bool sample_on_rising) { this->sample_on_rising_ = sample_on_rising; }
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
@@ -118,9 +119,10 @@ class ParadoxCombusComponent : public Component {
   std::string last_crc_fail_preview_;
   uint8_t last_crc_fail_cmd_{0};
   uint32_t frame_idle_us_{25000};
-  uint32_t sample_delay_us_{150};
+  uint32_t sample_delay_us_{350};
   uint32_t misaligned_frame_drops_{0};
   bool invert_data_{false};
+  bool sample_on_rising_{true};
   bool combus_connection_status_{false};
 
 };

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -33,8 +33,12 @@ paradox_combus:
   clk_pin: D1
   # Optional frame boundary idle timeout in microseconds.
   frame_idle_us: 25000
-  # Optional sample delay after each falling clock edge (40..250 us).
-  sample_delay_us: 150
+  # Optional sample delay after selected clock edge (40..900 us).
+  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
+  sample_delay_us: 350
+  # Sample on rising edge for slave->master packets (default).
+  # Set false to sample after falling edge if your wiring inverts bus phases.
+  sample_on_rising: true
   # Optional data polarity inversion for read sampling.
   invert_data: false
   # Legacy single data pin (shared read/write):
@@ -78,7 +82,7 @@ alarm_control_panel:
 ## Notes
 
 - The COMBUS parser/decoder remains based on the original implementation and now publishes directly to registered ESPHome entities.
-- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000` and `sample_delay_us: 150`.
+- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000`, `sample_on_rising: true`, and `sample_delay_us: 350` (then tune in ~50 us steps).
   Values like `frame_idle_us: 150000` can merge multiple packets into one frame and will usually prevent decoding.
 - If diagnostics show very low clock activity (for example tens of edges/sec), decoding will fail regardless of CRC/frame tuning; this usually points to wiring, pull-up, level-shifting, or optocoupler speed limits.
 - Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, plus either legacy `dta_pin` or split `read_pin`/`write_pin`).


### PR DESCRIPTION
### Motivation
- The COMBUS reader misaligned samples on 1 kHz buses where slave-driven data is valid during `CLOCK=high`, so sampling needed to be selectable by clock edge and tuned for ~1 ms cycles.
- The default hardcoded short sampling delay made mid-phase sampling unreliable for many optocoupler/wiring setups, requiring a more practical default and wider tuning range.

### Description
- Add a new YAML-configurable option `sample_on_rising` (default `true`) and corresponding C++ setter `set_sample_on_rising()` to control whether RX sampling is scheduled on clock rising or falling edges.
- Update `capture_combus_bits_()` to detect both rising and falling edges, keep falling-edge diagnostics, and schedule sampling based on the selected phase while preserving existing overflow and framing behavior.
- Change the `sample_delay_us` default to `350` and widen the valid range to `40..900` microseconds, and surface `sample_on_rising` in the startup log message for easier troubleshooting.
- Update `components/paradox_combus/__init__.py`, `paradox_combus.h`, `paradox_combus.cpp`, and documentation (`README.md` and `docs_esphome_native_component.md`) to reflect the new option and timing guidance.

### Testing
- Compiled the Python component module with `python -m compileall components/paradox_combus` and the compile step completed successfully.
- Performed static checks by running the project file diffs and inspected modified files to ensure the new configuration is wired into `to_code()` and startup logs were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15590f0a8832f902a6da6de692824)