### PR TITLE
paradox_combus: add rising-edge sampling, edge debounce and diagnostic counters; tune defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ paradox_combus:
   # Optional: frame split idle timeout (microseconds).
   # Increase if logs show mostly very short frames (<=8 bits).
   frame_idle_us: 25000
-  # Optional: sampling delay after each falling clock edge (40..250 us).
-  sample_delay_us: 150
+  # Optional: sampling delay after selected clock edge (40..900 us).
+  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
+  sample_delay_us: 350
+  # Sample on rising edge for slave->master packets (default).
+  # Set false to sample after falling edge if your wiring inverts bus phases.
+  sample_on_rising: true
+  # Reject clock transitions that arrive too quickly (noise/glitches).
+  # For 1 kHz COMBUS, start around 450-500 us.
+  min_edge_interval_us: 450
   # Optional: invert read polarity for troubleshooting optocoupler/wiring polarity.
   invert_data: false
   # Legacy/shared data line (single pin for read+write):

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -17,6 +17,8 @@ CONF_WRITE_PIN = "write_pin"
 CONF_FRAME_IDLE_US = "frame_idle_us"
 CONF_SAMPLE_DELAY_US = "sample_delay_us"
 CONF_INVERT_DATA = "invert_data"
+CONF_SAMPLE_ON_RISING = "sample_on_rising"
+CONF_MIN_EDGE_INTERVAL_US = "min_edge_interval_us"
 
 BASE_SCHEMA = cv.Schema(
     {
@@ -26,7 +28,9 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
         cv.Optional(CONF_FRAME_IDLE_US, default=25000): cv.int_range(min=2000, max=200000),
-        cv.Optional(CONF_SAMPLE_DELAY_US, default=150): cv.int_range(min=40, max=250),
+        cv.Optional(CONF_SAMPLE_DELAY_US, default=350): cv.int_range(min=40, max=900),
+        cv.Optional(CONF_SAMPLE_ON_RISING, default=True): cv.boolean,
+        cv.Optional(CONF_MIN_EDGE_INTERVAL_US, default=450): cv.int_range(min=0, max=5000),
         cv.Optional(CONF_INVERT_DATA, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -57,6 +61,8 @@ async def to_code(config):
     cg.add(var.set_clk_pin(clk))
     cg.add(var.set_frame_idle_us(config[CONF_FRAME_IDLE_US]))
     cg.add(var.set_sample_delay_us(config[CONF_SAMPLE_DELAY_US]))
+    cg.add(var.set_sample_on_rising(config[CONF_SAMPLE_ON_RISING]))
+    cg.add(var.set_min_edge_interval_us(config[CONF_MIN_EDGE_INTERVAL_US]))
     cg.add(var.set_invert_data(config[CONF_INVERT_DATA]))
 
     if CONF_DTA_PIN in config:

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -105,13 +105,30 @@ void ParadoxCombusComponent::capture_combus_bits_() {
 
   const unsigned long now = micros();
   const bool clk_state = this->clk_pin_->digital_read();
+  const bool clk_rising = !this->last_clk_state_ && clk_state;
+  const bool clk_falling = this->last_clk_state_ && !clk_state;
+  const bool has_clk_edge = clk_rising || clk_falling;
 
-  if (this->last_clk_state_ && !clk_state) {
+  if (has_clk_edge) {
+    const uint32_t edge_interval = static_cast<uint32_t>(now - this->last_accepted_clk_edge_at_);
+    if (this->last_accepted_clk_edge_at_ != 0 && edge_interval < this->min_edge_interval_us_) {
+      this->rejected_clock_edges_++;
+      this->last_clk_state_ = clk_state;
+      return;
+    }
+    this->last_accepted_clk_edge_at_ = now;
+  }
+
+  if (clk_falling) {
     this->last_clk_signal_ = now;
-    this->pending_sample_at_ = now + this->sample_delay_us_;
-    this->sample_pending_ = true;
     this->clock_falling_edges_++;
   }
+
+  if ((this->sample_on_rising_ && clk_rising) || (!this->sample_on_rising_ && clk_falling)) {
+    this->pending_sample_at_ = now + this->sample_delay_us_;
+    this->sample_pending_ = true;
+  }
+
   this->last_clk_state_ = clk_state;
 
   if (!this->sample_pending_ || static_cast<long>(now - this->pending_sample_at_) < 0) {
@@ -239,7 +256,9 @@ void ParadoxCombusComponent::connect_combus_() {
   this->sample_pending_ = false;
   this->last_clk_signal_ = micros();
   this->last_diag_log_at_ = this->last_clk_signal_;
+  this->last_accepted_clk_edge_at_ = 0;
   this->clock_falling_edges_ = 0;
+  this->rejected_clock_edges_ = 0;
   this->sampled_bits_ = 0;
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;
@@ -253,9 +272,11 @@ void ParadoxCombusComponent::connect_combus_() {
   this->bus_message_.clear();
 
   this->combus_connection_status_ = true;
-  ESP_LOGI(TAG, "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, invert_data=%s)",
+  ESP_LOGI(TAG,
+           "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, sample_on_rising=%s, "
+           "min_edge_interval_us=%u, invert_data=%s)",
            static_cast<unsigned>(this->frame_idle_us_), static_cast<unsigned>(this->sample_delay_us_),
-           YESNO(this->invert_data_));
+           YESNO(this->sample_on_rising_), static_cast<unsigned>(this->min_edge_interval_us_), YESNO(this->invert_data_));
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {
@@ -325,10 +346,12 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
              this->clk_pin_->digital_read(), this->read_pin_->digital_read());
   } else {
     ESP_LOGD(TAG,
-             "COMBUS diag (5s): clk_edges=%u sampled_bits=%u decoded=%u crc_drop=%u overflow_drop=%u tx_pending_bits=%u",
-             static_cast<unsigned>(this->clock_falling_edges_), static_cast<unsigned>(this->sampled_bits_),
-             static_cast<unsigned>(this->decoded_frames_), static_cast<unsigned>(this->crc_drop_frames_),
-             static_cast<unsigned>(this->overflow_drop_frames_), static_cast<unsigned>(this->tx_bits_.size()));
+             "COMBUS diag (5s): clk_edges=%u rejected_edges=%u sampled_bits=%u decoded=%u crc_drop=%u "
+             "overflow_drop=%u tx_pending_bits=%u",
+             static_cast<unsigned>(this->clock_falling_edges_), static_cast<unsigned>(this->rejected_clock_edges_),
+             static_cast<unsigned>(this->sampled_bits_), static_cast<unsigned>(this->decoded_frames_),
+             static_cast<unsigned>(this->crc_drop_frames_), static_cast<unsigned>(this->overflow_drop_frames_),
+             static_cast<unsigned>(this->tx_bits_.size()));
 
     ESP_LOGD(TAG,
              "COMBUS frame lens (5s): <=8=%u 9-16=%u 17-32=%u 33-64=%u 65-96=%u 97-128=%u 129-160=%u >160=%u "
@@ -348,12 +371,13 @@ void ParadoxCombusComponent::log_bus_diagnostics_() {
       ESP_LOGW(TAG,
                "Very low COMBUS clock activity detected (%.1f falling edges/sec). "
                "This usually indicates wiring/level-shifting/sampling issues. "
-               "Try invert_data, reduce sample_delay_us, and verify optocoupler speed.",
+               "Try invert_data, tune min_edge_interval_us/sample_delay_us, and verify optocoupler speed.",
                edges_per_second);
     }
   }
 
   this->clock_falling_edges_ = 0;
+  this->rejected_clock_edges_ = 0;
   this->sampled_bits_ = 0;
   this->decoded_frames_ = 0;
   this->crc_drop_frames_ = 0;

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -38,6 +38,8 @@ class ParadoxCombusComponent : public Component {
   void set_frame_idle_us(uint32_t frame_idle_us) { this->frame_idle_us_ = frame_idle_us; }
   void set_sample_delay_us(uint32_t sample_delay_us) { this->sample_delay_us_ = sample_delay_us; }
   void set_invert_data(bool invert_data) { this->invert_data_ = invert_data; }
+  void set_sample_on_rising(bool sample_on_rising) { this->sample_on_rising_ = sample_on_rising; }
+  void set_min_edge_interval_us(uint32_t min_edge_interval_us) { this->min_edge_interval_us_ = min_edge_interval_us; }
 
   void register_zone_sensor(uint8_t zone, binary_sensor::BinarySensor *sensor);
   void set_alarm_control_panel(ParadoxAlarmControlPanel *panel) { this->alarm_control_panel_ = panel; }
@@ -107,7 +109,9 @@ class ParadoxCombusComponent : public Component {
   unsigned long pending_sample_at_{0};
   unsigned long last_clk_signal_{0};
   unsigned long last_diag_log_at_{0};
+  unsigned long last_accepted_clk_edge_at_{0};
   uint32_t clock_falling_edges_{0};
+  uint32_t rejected_clock_edges_{0};
   uint32_t sampled_bits_{0};
   uint32_t decoded_frames_{0};
   uint32_t crc_drop_frames_{0};
@@ -118,9 +122,11 @@ class ParadoxCombusComponent : public Component {
   std::string last_crc_fail_preview_;
   uint8_t last_crc_fail_cmd_{0};
   uint32_t frame_idle_us_{25000};
-  uint32_t sample_delay_us_{150};
+  uint32_t sample_delay_us_{350};
+  uint32_t min_edge_interval_us_{450};
   uint32_t misaligned_frame_drops_{0};
   bool invert_data_{false};
+  bool sample_on_rising_{true};
   bool combus_connection_status_{false};
 
 };

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -33,8 +33,15 @@ paradox_combus:
   clk_pin: D1
   # Optional frame boundary idle timeout in microseconds.
   frame_idle_us: 25000
-  # Optional sample delay after each falling clock edge (40..250 us).
-  sample_delay_us: 150
+  # Optional sample delay after selected clock edge (40..900 us).
+  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
+  sample_delay_us: 350
+  # Sample on rising edge for slave->master packets (default).
+  # Set false to sample after falling edge if your wiring inverts bus phases.
+  sample_on_rising: true
+  # Reject clock transitions that arrive too quickly (noise/glitches).
+  # For 1 kHz COMBUS, start around 450-500 us.
+  min_edge_interval_us: 450
   # Optional data polarity inversion for read sampling.
   invert_data: false
   # Legacy single data pin (shared read/write):
@@ -78,7 +85,7 @@ alarm_control_panel:
 ## Notes
 
 - The COMBUS parser/decoder remains based on the original implementation and now publishes directly to registered ESPHome entities.
-- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000` and `sample_delay_us: 150`.
+- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000`, `sample_on_rising: true`, `min_edge_interval_us: 450`, and `sample_delay_us: 350` (then tune in ~50 us steps).
   Values like `frame_idle_us: 150000` can merge multiple packets into one frame and will usually prevent decoding.
 - If diagnostics show very low clock activity (for example tens of edges/sec), decoding will fail regardless of CRC/frame tuning; this usually points to wiring, pull-up, level-shifting, or optocoupler speed limits.
 - Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, plus either legacy `dta_pin` or split `read_pin`/`write_pin`).


### PR DESCRIPTION
### Motivation

- Improve robustness and configurability of COMBUS sampling to handle optocoupler delays and noisy clock edges.
- Expose additional YAML options to let users choose sampling edge and filter out spurious clock transitions.
- Provide better diagnostics to help tune timing parameters when decoding/CRC failures occur.

### Description

- Added new YAML options `sample_on_rising` and `min_edge_interval_us`, increased `sample_delay_us` default to 350, and extended the allowed `sample_delay_us` range to 900 in `__init__.py`, `README.md`, and docs.
- Implemented rising-edge vs falling-edge sampling and edge-rate filtering in `paradox_combus.cpp`, including `last_accepted_clk_edge_at_`, `rejected_clock_edges_`, and logic to only accept edges separated by `min_edge_interval_us_`.
- Added setters and member variables for `sample_on_rising` and `min_edge_interval_us` in `paradox_combus.h`, bumped `sample_delay_us_` default, and exposed the new settings to the code generator in `to_code`.
- Enhanced diagnostic logging to include rejected clock edges and to surface the new configuration parameters in the initialization log, and updated documentation examples to recommend tuned defaults.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a15590f0a8832f902a6da6de692824)