### PR TITLE
paradox_combus: adaptive sampling for polling mode and updated timing defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ paradox_combus:
   clk_pin: D1
   # Optional: frame split idle timeout (microseconds).
   # Increase if logs show mostly very short frames (<=8 bits).
-  frame_idle_us: 25000
+  frame_idle_us: 10000
   # Optional: sampling delay after selected clock edge (40..900 us).
-  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
-  sample_delay_us: 350
-  # Sample on rising edge for slave->master packets (default).
-  # Set false to sample after falling edge if your wiring inverts bus phases.
-  sample_on_rising: true
+  # `0` enables adaptive delay based on observed clock half-cycle (recommended on ESP32 polling).
+  # Set a fixed value (e.g. 120-250) only for manual tuning.
+  sample_delay_us: 0
+  # Sample on falling edge by default (matches legacy branch behaviour).
+  # Set true if your wiring/level shifting captures cleaner data on rising edges.
+  sample_on_rising: false
   # Reject clock transitions that arrive too quickly (noise/glitches).
-  # For 1 kHz COMBUS, start around 450-500 us.
-  min_edge_interval_us: 450
+  # For 1 kHz COMBUS, start around 80-150 us.
+  min_edge_interval_us: 100
   # Optional: invert read polarity for troubleshooting optocoupler/wiring polarity.
   invert_data: false
   # Legacy/shared data line (single pin for read+write):
@@ -88,6 +89,14 @@ alarm_control_panel:
 
 `disarm_sequence` now accepts an ASCII string (for example `"1234"`) in addition to raw hex bytes.
 If `disarm_sequence` is omitted, disarm is not exposed as a writable feature.
+
+### Legacy branch timing baseline (why `master` used to work)
+
+The old interrupt-driven implementation sampled on **falling** edges with a fixed ~**150 us** timer offset.
+`v2` is polling-based on ESP32/ESP-IDF, so exact ISR timing no longer exists; it now uses adaptive delay by default (`sample_delay_us: 0`) to derive sampling point from the measured clock period.
+
+If decoding is still unstable on ESP32 + `esp-idf`, keep `invert_data: false`, start with `min_edge_interval_us: 100`, and temporarily remove `write_pin` while validating receive-only traffic.
+
 
 For a full multi-zone example, see `alarm-example.yaml`.
 

--- a/components/paradox_combus/__init__.py
+++ b/components/paradox_combus/__init__.py
@@ -27,10 +27,10 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_DTA_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_READ_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_WRITE_PIN): pins.internal_gpio_output_pin_schema,
-        cv.Optional(CONF_FRAME_IDLE_US, default=25000): cv.int_range(min=2000, max=200000),
-        cv.Optional(CONF_SAMPLE_DELAY_US, default=350): cv.int_range(min=40, max=900),
-        cv.Optional(CONF_SAMPLE_ON_RISING, default=True): cv.boolean,
-        cv.Optional(CONF_MIN_EDGE_INTERVAL_US, default=450): cv.int_range(min=0, max=5000),
+        cv.Optional(CONF_FRAME_IDLE_US, default=10000): cv.int_range(min=2000, max=200000),
+        cv.Optional(CONF_SAMPLE_DELAY_US, default=0): cv.int_range(min=0, max=900),
+        cv.Optional(CONF_SAMPLE_ON_RISING, default=False): cv.boolean,
+        cv.Optional(CONF_MIN_EDGE_INTERVAL_US, default=100): cv.int_range(min=0, max=5000),
         cv.Optional(CONF_INVERT_DATA, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/components/paradox_combus/paradox_combus.cpp
+++ b/components/paradox_combus/paradox_combus.cpp
@@ -116,6 +116,9 @@ void ParadoxCombusComponent::capture_combus_bits_() {
       this->last_clk_state_ = clk_state;
       return;
     }
+    if (this->last_accepted_clk_edge_at_ != 0) {
+      this->last_clk_edge_interval_us_ = edge_interval;
+    }
     this->last_accepted_clk_edge_at_ = now;
   }
 
@@ -125,7 +128,22 @@ void ParadoxCombusComponent::capture_combus_bits_() {
   }
 
   if ((this->sample_on_rising_ && clk_rising) || (!this->sample_on_rising_ && clk_falling)) {
-    this->pending_sample_at_ = now + this->sample_delay_us_;
+    uint32_t effective_sample_delay_us = this->sample_delay_us_;
+    if (effective_sample_delay_us == 0) {
+      if (this->last_clk_edge_interval_us_ != 0) {
+        // Polling loop has scheduling jitter; sample around 1/3 of the observed half-cycle by default.
+        effective_sample_delay_us = this->last_clk_edge_interval_us_ / 3;
+        if (effective_sample_delay_us < 80) {
+          effective_sample_delay_us = 80;
+        } else if (effective_sample_delay_us > 450) {
+          effective_sample_delay_us = 450;
+        }
+      } else {
+        effective_sample_delay_us = 150;
+      }
+    }
+
+    this->pending_sample_at_ = now + effective_sample_delay_us;
     this->sample_pending_ = true;
   }
 
@@ -257,6 +275,7 @@ void ParadoxCombusComponent::connect_combus_() {
   this->last_clk_signal_ = micros();
   this->last_diag_log_at_ = this->last_clk_signal_;
   this->last_accepted_clk_edge_at_ = 0;
+  this->last_clk_edge_interval_us_ = 0;
   this->clock_falling_edges_ = 0;
   this->rejected_clock_edges_ = 0;
   this->sampled_bits_ = 0;
@@ -273,10 +292,11 @@ void ParadoxCombusComponent::connect_combus_() {
 
   this->combus_connection_status_ = true;
   ESP_LOGI(TAG,
-           "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u, sample_on_rising=%s, "
+           "COMBUS initialized in polling mode (frame_idle_us=%u, sample_delay_us=%u%s, sample_on_rising=%s, "
            "min_edge_interval_us=%u, invert_data=%s)",
            static_cast<unsigned>(this->frame_idle_us_), static_cast<unsigned>(this->sample_delay_us_),
-           YESNO(this->sample_on_rising_), static_cast<unsigned>(this->min_edge_interval_us_), YESNO(this->invert_data_));
+           this->sample_delay_us_ == 0 ? " (auto)" : "", YESNO(this->sample_on_rising_),
+           static_cast<unsigned>(this->min_edge_interval_us_), YESNO(this->invert_data_));
 }
 
 void ParadoxCombusComponent::disconnect_combus_() {

--- a/components/paradox_combus/paradox_combus.h
+++ b/components/paradox_combus/paradox_combus.h
@@ -110,6 +110,7 @@ class ParadoxCombusComponent : public Component {
   unsigned long last_clk_signal_{0};
   unsigned long last_diag_log_at_{0};
   unsigned long last_accepted_clk_edge_at_{0};
+  uint32_t last_clk_edge_interval_us_{0};
   uint32_t clock_falling_edges_{0};
   uint32_t rejected_clock_edges_{0};
   uint32_t sampled_bits_{0};
@@ -121,12 +122,12 @@ class ParadoxCombusComponent : public Component {
   uint32_t malformed_d1_d0_frames_{0};
   std::string last_crc_fail_preview_;
   uint8_t last_crc_fail_cmd_{0};
-  uint32_t frame_idle_us_{25000};
-  uint32_t sample_delay_us_{350};
-  uint32_t min_edge_interval_us_{450};
+  uint32_t frame_idle_us_{10000};
+  uint32_t sample_delay_us_{0};
+  uint32_t min_edge_interval_us_{100};
   uint32_t misaligned_frame_drops_{0};
   bool invert_data_{false};
-  bool sample_on_rising_{true};
+  bool sample_on_rising_{false};
   bool combus_connection_status_{false};
 
 };

--- a/docs_esphome_native_component.md
+++ b/docs_esphome_native_component.md
@@ -32,16 +32,16 @@ paradox_combus:
   id: combus
   clk_pin: D1
   # Optional frame boundary idle timeout in microseconds.
-  frame_idle_us: 25000
+  frame_idle_us: 10000
   # Optional sample delay after selected clock edge (40..900 us).
-  # Paradox COMBUS at 1 kHz often needs ~300-500 us for stable reads.
-  sample_delay_us: 350
-  # Sample on rising edge for slave->master packets (default).
-  # Set false to sample after falling edge if your wiring inverts bus phases.
-  sample_on_rising: true
+  # `0` enables adaptive delay derived from observed clock timing (recommended for polling mode).
+  sample_delay_us: 0
+  # Sample on falling edge by default (legacy-compatible baseline).
+  # Set true only if your wiring captures cleaner data on rising edges.
+  sample_on_rising: false
   # Reject clock transitions that arrive too quickly (noise/glitches).
-  # For 1 kHz COMBUS, start around 450-500 us.
-  min_edge_interval_us: 450
+  # For 1 kHz COMBUS, start around 80-150 us.
+  min_edge_interval_us: 100
   # Optional data polarity inversion for read sampling.
   invert_data: false
   # Legacy single data pin (shared read/write):
@@ -85,7 +85,7 @@ alarm_control_panel:
 ## Notes
 
 - The COMBUS parser/decoder remains based on the original implementation and now publishes directly to registered ESPHome entities.
-- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 25000`, `sample_on_rising: true`, `min_edge_interval_us: 450`, and `sample_delay_us: 350` (then tune in ~50 us steps).
+- If logs show repeated `bit length not byte-aligned` or `CRC mismatch` drops, start from `frame_idle_us: 10000`, `sample_on_rising: false`, `min_edge_interval_us: 100`, and `sample_delay_us: 0 (auto)` (then tune in ~50 us steps).
   Values like `frame_idle_us: 150000` can merge multiple packets into one frame and will usually prevent decoding.
 - If diagnostics show very low clock activity (for example tens of edges/sec), decoding will fail regardless of CRC/frame tuning; this usually points to wiring, pull-up, level-shifting, or optocoupler speed limits.
 - Pin configuration moved from hardcoded C++ defines to YAML (`clk_pin`, plus either legacy `dta_pin` or split `read_pin`/`write_pin`).


### PR DESCRIPTION
### Motivation
- Improve reliability of ESP32/ESP-IDF polling-based COMBUS decoding by deriving the sample point from observed clock timing instead of a fixed ISR-derived offset.
- Make the component defaults match the new polling behavior and the legacy branch baseline for easier out-of-the-box operation.
- Provide clearer documentation and guidance for tuning timing parameters in `README.md` and `docs_esphome_native_component.md`.

### Description
- Implement adaptive sampling in `paradox_combus.cpp` when `sample_delay_us == 0` by measuring the last accepted clock edge interval and computing a sampling delay (1/3 of half-cycle, clamped 80..450 us), with a fallback of 150 us; track `last_clk_edge_interval_us_` to support this.
- Update internal defaults and YAML schema in `__init__.py` and `paradox_combus.h` to `frame_idle_us: 10000`, `sample_delay_us: 0`, `sample_on_rising: false`, and `min_edge_interval_us: 100` and allow `sample_delay_us` to be zero in the schema.
- Adjust clock-edge acceptance logic to record `last_clk_edge_interval_us_` and initialize it in `connect_combus_`, and update the connection log to indicate when `sample_delay_us` is in automatic mode.
- Update `README.md` and `docs_esphome_native_component.md` with new default values, explanatory notes about the legacy baseline, and tuning recommendations for Debug/diagnostics.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56cf528f8832f9055a26cabf8777a)